### PR TITLE
[u" is not a valid value for enum <enum 'MyEnumClass'>"] when doing an add in Django admin

### DIFF
--- a/tests/admin.py
+++ b/tests/admin.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from django.contrib import admin
+from .models import MyModel
+from django.contrib.admin.sites import AdminSite, site
+
+myadminsite = AdminSite()
+
+
+class MyModelAdmin(admin.ModelAdmin):
+    model = MyModel
+
+myadminsite.register(MyModel, MyModelAdmin)


### PR DESCRIPTION
When using the enum field on a related field with the green add button, I get an error saying u'' is not a valid value. The test I wrote replicates the same error. I tried to debug (and will keep doing so) but I cannot figure out why its losing its value.
