### PR TITLE
Ensure Django uses the label for displaying

### DIFF
--- a/enumfields/enums.py
+++ b/enumfields/enums.py
@@ -1,4 +1,5 @@
 import inspect
+from django.utils.encoding import force_bytes, python_2_unicode_compatible
 from enum import Enum as BaseEnum, EnumMeta as BaseEnumMeta
 import six
 
@@ -20,6 +21,7 @@ class EnumMeta(BaseEnumMeta):
         return obj
 
 
+@python_2_unicode_compatible
 class Enum(six.with_metaclass(EnumMeta, BaseEnum)):
     @classmethod
     def choices(cls):
@@ -28,3 +30,9 @@ class Enum(six.with_metaclass(EnumMeta, BaseEnum)):
         (See https://docs.djangoproject.com/en/dev/ref/models/fields/#choices)
         """
         return tuple((m.value, m.label) for m in cls)
+
+    def __str__(self):
+        """
+        Show our label when Django uses the Enum for displaying in a view
+        """
+        return force_bytes(self.label)


### PR DESCRIPTION
This ensures the label is visible in error messages and select boxes, for example.

Note:
I'll divide my changes up in smaller Pull Requests so they can be selectively applied if they conflict with another Pull Request.
