### PR TITLE
remove choices from kwargs in field deconstruct

### DIFF
--- a/enumfields/fields.py
+++ b/enumfields/fields.py
@@ -56,6 +56,8 @@ class EnumFieldMixin(six.with_metaclass(models.SubfieldBase)):
     def deconstruct(self):
         name, path, args, kwargs = super(EnumFieldMixin, self).deconstruct()
         kwargs['enum'] = self.enum
+        if 'choices' in kwargs:
+            del kwargs['choices']
         return name, path, args, kwargs
 
 


### PR DESCRIPTION
Since we are adding a choices kwarg to the base field (in EnumFieldMixin.**init**) we need to remove it when deconstructing. Otherwise django tries (and fails) to serialize the Enums and pass the choices as arguments when reconstructing.
