### PR TITLE
Add new required middleware to make tests pass on Django 1.7

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -17,6 +17,12 @@ DATABASES = {
     },
 }
 
+MIDDLEWARE_CLASSES = (
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+)
+
 DEBUG = True
 
 STATIC_URL = "/static/"


### PR DESCRIPTION
# Django 1.6

```
> pip install "Django<1.7"
  Downloading Django-1.6.8.tar.gz (6.7MB): 6.7MB downloaded

> python setup.py test
============================= test session starts =============================
platform win32 -- Python 2.7.5 -- py-1.4.26 -- pytest-2.6.4
plugins: django
collected 7 items

tests/test_enums.py .......Destroying test database for alias 'default'...

========================== 7 passed in 3.91 seconds ===========================
```
# Django 1.7

```
> pip install django==1.7.1
Downloading/unpacking django==1.7.1
Successfully installed django

> python setup.py test
============================= test session starts =============================
platform win32 -- Python 2.7.5 -- py-1.4.26 -- pytest-2.6.4
plugins: django
collected 7 items

tests/test_enums.py .......Destroying test database for alias 'default'...

========================== 7 passed in 3.59 seconds ===========================
```
