### PR TITLE
Choices and labels, oh my!

### DIFF
--- a/enumfields/fields.py
+++ b/enumfields/fields.py
@@ -18,7 +18,7 @@ class EnumFieldMixin(six.with_metaclass(models.SubfieldBase)):
             self.enum = enum
 
         if "choices" not in options:
-            options["choices"] = [(i, i.name) for i in self.enum]  # choices for the TypedChoiceField
+            options["choices"] = [(i, getattr(i, 'label', i.name)) for i in self.enum]  # choices for the TypedChoiceField
 
         super(EnumFieldMixin, self).__init__(**options)
 

--- a/enumfields/fields.py
+++ b/enumfields/fields.py
@@ -2,7 +2,7 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from enum import Enum
 import six
-from django.db.models.fields import NOT_PROVIDED
+from django.db.models.fields import NOT_PROVIDED, BLANK_CHOICE_DASH
 
 try:
     from django.utils.module_loading import import_string
@@ -66,6 +66,15 @@ class EnumFieldMixin(six.with_metaclass(models.SubfieldBase)):
                 kwargs["default"] = kwargs["default"].value
 
         return name, path, args, kwargs
+
+    def get_choices(self, include_blank=True, blank_choice=BLANK_CHOICE_DASH):
+        # Force enum fields' options to use the `value` of the enumeration
+        # member as the `value` of SelectFields and similar.
+        return [
+            (i.value if i else i, display)
+            for (i, display)
+            in super(EnumFieldMixin, self).get_choices(include_blank, blank_choice)
+        ]
 
 
 class EnumField(EnumFieldMixin, models.CharField):

--- a/tests/test_django_admin.py
+++ b/tests/test_django_admin.py
@@ -1,0 +1,63 @@
+# -- encoding: UTF-8 --
+
+import uuid
+
+from django.contrib.auth import get_user_model
+from django.core.urlresolvers import reverse
+from django.test import Client
+import pytest
+from enumfields import EnumIntegerField
+from .models import MyModel
+
+
+@pytest.fixture
+def client():
+    return Client()
+
+
+SUPERUSER_USERNAME = "superuser"
+SUPERUSER_PASS = "superpass"
+
+
+@pytest.fixture
+def superuser():
+    return get_user_model().objects.create_superuser(username=SUPERUSER_USERNAME, password=SUPERUSER_PASS,
+                                                     email="billgates@microsoft.com")
+
+
+@pytest.fixture
+def superuser_client(client, superuser):
+    client.login(username=SUPERUSER_USERNAME, password=SUPERUSER_PASS)
+    return client
+
+
+@pytest.mark.django_db
+@pytest.mark.urls('tests.urls')
+def test_model_admin(superuser_client):
+    url = reverse("admin:tests_mymodel_add")
+    secret_uuid = str(uuid.uuid4())
+    post_data = {
+        'color': MyModel.Color.RED.value,
+        'taste': MyModel.Taste.UMAMI.value,
+        'taste_int': MyModel.Taste.SWEET.value,
+        'random_code': secret_uuid
+    }
+    response = superuser_client.post(url, follow=True, data=post_data)
+    response.render()
+    text = response.content
+
+    assert b"This field is required" not in text
+    assert b"Select a valid choice" not in text
+    try:
+        inst = MyModel.objects.get(random_code=secret_uuid)
+    except MyModel.DoesNotExist:
+        assert False, "Object wasn't created in the database"
+    assert inst.color == MyModel.Color.RED, "Redness not assured"
+    assert inst.taste == MyModel.Taste.UMAMI, "Umami not there"
+    assert inst.taste_int == MyModel.Taste.SWEET, "Not sweet enough"
+
+
+def test_django_admin_lookup_value_for_integer_enum_field():
+    field = EnumIntegerField(MyModel.Taste)
+
+    assert field.get_prep_value(str(MyModel.Taste.BITTER)) == 3, "get_prep_value should be able to convert from strings"

--- a/tests/test_django_models.py
+++ b/tests/test_django_models.py
@@ -1,0 +1,36 @@
+# -- encoding: UTF-8 --
+
+from django.db import connection
+import pytest
+from .models import MyModel
+
+
+@pytest.mark.django_db
+def test_field_value():
+    m = MyModel(color=MyModel.Color.RED)
+    m.save()
+    assert m.color == MyModel.Color.RED
+
+    m = MyModel.objects.filter(color=MyModel.Color.RED)[0]
+    assert m.color == MyModel.Color.RED
+
+
+@pytest.mark.django_db
+def test_db_value():
+    m = MyModel(color=MyModel.Color.RED)
+    m.save()
+    cursor = connection.cursor()
+    cursor.execute('SELECT color FROM %s WHERE id = %%s' % MyModel._meta.db_table, [m.pk])
+    assert cursor.fetchone()[0] == MyModel.Color.RED.value
+
+
+@pytest.mark.django_db
+def test_zero_enum_loads():
+    # Verifies that we can save and load enums with the value of 0 (zero).
+    m = MyModel(zero_field=MyModel.ZeroEnum.ZERO,
+                color=MyModel.Color.GREEN)
+    m.save()
+    assert m.zero_field == MyModel.ZeroEnum.ZERO
+
+    m = MyModel.objects.get(id=m.id)
+    assert m.zero_field == MyModel.ZeroEnum.ZERO

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,16 +1,8 @@
 # -- encoding: UTF-8 --
 
-import uuid
-
-from django.contrib.auth import get_user_model
-from django.core.urlresolvers import reverse
-from django.db import connection
 from django.forms import BaseForm
-from django.test import Client
 from django.utils.translation import ugettext_lazy
-import pytest
-from enumfields import Enum, EnumField, EnumIntegerField
-from .models import MyModel
+from enumfields import Enum, EnumField
 import six
 
 
@@ -66,87 +58,3 @@ def test_formfield_functionality():
     form = form_cls(data={"color": "r"})
     assert not form.errors
     assert form.cleaned_data["color"] == Color.RED
-
-
-@pytest.mark.django_db
-def test_field_value():
-    m = MyModel(color=MyModel.Color.RED)
-    m.save()
-    assert m.color == MyModel.Color.RED
-
-    m = MyModel.objects.filter(color=MyModel.Color.RED)[0]
-    assert m.color == MyModel.Color.RED
-
-
-@pytest.mark.django_db
-def test_db_value():
-    m = MyModel(color=MyModel.Color.RED)
-    m.save()
-    cursor = connection.cursor()
-    cursor.execute('SELECT color FROM %s WHERE id = %%s' % MyModel._meta.db_table, [m.pk])
-    assert cursor.fetchone()[0] == MyModel.Color.RED.value
-
-
-@pytest.fixture
-def client():
-    return Client()
-
-
-SUPERUSER_USERNAME = "superuser"
-SUPERUSER_PASS = "superpass"
-
-
-@pytest.fixture
-def superuser():
-    return get_user_model().objects.create_superuser(username=SUPERUSER_USERNAME, password=SUPERUSER_PASS,
-                                                     email="billgates@microsoft.com")
-
-
-@pytest.fixture
-def superuser_client(client, superuser):
-    client.login(username=SUPERUSER_USERNAME, password=SUPERUSER_PASS)
-    return client
-
-
-@pytest.mark.django_db
-@pytest.mark.urls('tests.urls')
-def test_model_admin(superuser_client):
-    url = reverse("admin:tests_mymodel_add")
-    secret_uuid = str(uuid.uuid4())
-    post_data = {
-        'color': MyModel.Color.RED.value,
-        'taste': MyModel.Taste.UMAMI.value,
-        'taste_int': MyModel.Taste.SWEET.value,
-        'random_code': secret_uuid
-    }
-    response = superuser_client.post(url, follow=True, data=post_data)
-    response.render()
-    text = response.content
-
-    assert b"This field is required" not in text
-    assert b"Select a valid choice" not in text
-    try:
-        inst = MyModel.objects.get(random_code=secret_uuid)
-    except MyModel.DoesNotExist:
-        assert False, "Object wasn't created in the database"
-    assert inst.color == MyModel.Color.RED, "Redness not assured"
-    assert inst.taste == MyModel.Taste.UMAMI, "Umami not there"
-    assert inst.taste_int == MyModel.Taste.SWEET, "Not sweet enough"
-
-
-def test_django_admin_lookup_value_for_integer_enum_field():
-    field = EnumIntegerField(MyModel.Taste)
-
-    assert field.get_prep_value(str(MyModel.Taste.BITTER)) == 3, "get_prep_value should be able to convert from strings"
-
-
-@pytest.mark.django_db
-def test_zero_enum_loads():
-    # Verifies that we can save and load enums with the value of 0 (zero).
-    m = MyModel(zero_field=MyModel.ZeroEnum.ZERO,
-                color=MyModel.Color.GREEN)
-    m.save()
-    assert m.zero_field == MyModel.ZeroEnum.ZERO
-
-    m = MyModel.objects.get(id=m.id)
-    assert m.zero_field == MyModel.ZeroEnum.ZERO

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -5,53 +5,67 @@ import uuid
 from django.contrib.auth import get_user_model
 from django.core.urlresolvers import reverse
 from django.db import connection
+from django.forms import BaseForm
 from django.test import Client
 from django.utils.translation import ugettext_lazy
 import pytest
-
-from enumfields import Enum
-from enumfields.fields import EnumIntegerField
+from enumfields import Enum, EnumField, EnumIntegerField
 from .models import MyModel
 import six
 
 
-def test_choices():
-    class Color(Enum):
-        __order__ = 'RED GREEN BLUE'
+class Color(Enum):
+    __order__ = 'RED GREEN BLUE'
 
-        RED = 'r'
-        GREEN = 'g'
-        BLUE = 'b'
+    GREEN = 'g'
+    RED = 'r'
+    BLUE = 'b'
 
-    COLOR_CHOICES = (
-        ('r', 'Red'),
+    class Labels:
+        RED = 'Reddish'
+        BLUE = ugettext_lazy(u'bluë')
+
+
+def test_choice_ordering():
+    EXPECTED_CHOICES = (
+        ('r', 'Reddish'),
         ('g', 'Green'),
-        ('b', 'Blue'),
+        ('b', u'bluë'),
     )
-    assert Color.choices() == COLOR_CHOICES
+    for ((ex_key, ex_val), (key, val)) in zip(EXPECTED_CHOICES, Color.choices()):
+        assert key == ex_key
+        assert six.text_type(val) == six.text_type(ex_val)
 
-
-def test_labels():
-    class Color(Enum):
-        RED = 'r'
-        GREEN = 'g'
-        BLUE = 'b'
-
-        class Labels:
-            RED = 'A custom label'
-            BLUE = ugettext_lazy(u'bluë')
-
+def test_custom_labels():
     # Custom label
-    assert Color.RED.label == 'A custom label'
-    assert six.text_type(Color.RED) == 'A custom label'
+    assert Color.RED.label == 'Reddish'
+    assert six.text_type(Color.RED) == 'Reddish'
 
+def test_automatic_labels():
     # Automatic label
     assert Color.GREEN.label == 'Green'
     assert six.text_type(Color.GREEN) == 'Green'
 
+def test_lazy_labels():
     # Lazy label
     assert isinstance(six.text_type(Color.BLUE), six.string_types)
     assert six.text_type(Color.BLUE) == u'bluë'
+
+def test_formfield_labels():
+    # Formfield choice label
+    form_field = EnumField(Color).formfield()
+    expectations = dict((val.value, six.text_type(val)) for val in Color)
+    for value, text in form_field.choices:
+        if value:
+            assert text == expectations[value]
+
+def test_formfield_functionality():
+    form_cls = type("FauxForm", (BaseForm,), {
+        "base_fields": {"color": EnumField(Color).formfield()}
+    })
+    form = form_cls(data={"color": "r"})
+    assert not form.errors
+    assert form.cleaned_data["color"] == Color.RED
 
 
 @pytest.mark.django_db

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -113,18 +113,25 @@ def superuser_client(client, superuser):
 def test_model_admin(superuser_client):
     url = reverse("admin:tests_mymodel_add")
     secret_uuid = str(uuid.uuid4())
-    response = superuser_client.post(url, follow=True, data={
-        'color': 'Color.RED',
-        'taste': 'Taste.UMAMI',
-        'taste_int': 'Taste.SWEET',
+    post_data = {
+        'color': MyModel.Color.RED.value,
+        'taste': MyModel.Taste.UMAMI.value,
+        'taste_int': MyModel.Taste.SWEET.value,
         'random_code': secret_uuid
-    })
+    }
+    response = superuser_client.post(url, follow=True, data=post_data)
     response.render()
     text = response.content
 
     assert b"This field is required" not in text
     assert b"Select a valid choice" not in text
-    assert MyModel.objects.filter(random_code=secret_uuid).exists(), "Object wasn't created in the database"
+    try:
+        inst = MyModel.objects.get(random_code=secret_uuid)
+    except MyModel.DoesNotExist:
+        assert False, "Object wasn't created in the database"
+    assert inst.color == MyModel.Color.RED, "Redness not assured"
+    assert inst.taste == MyModel.Taste.UMAMI, "Umami not there"
+    assert inst.taste_int == MyModel.Taste.SWEET, "Not sweet enough"
 
 
 def test_django_admin_lookup_value_for_integer_enum_field():


### PR DESCRIPTION
I first started to fix #23 (since I bumped into the same problem), but then I went further down the rabbit hole and ended up also changing the semantics of how `EnumField`s are turned into `ChoiceField` form fields...

From here on out, we'll use the `.value` of the enum entry, instead of a `str` representation of the enum entry itself (which could be accidentally duplicate -- bad times!).

Just a heads-up: That change will obviously break any pre-existing tests in client code that expect the `<option>` values to be, say, `"Taste.UMAMI"` instead of `"3"` or whatnot...