### PR TITLE
Fix form field regression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,11 @@
 /.env
 /dist
 /MANIFEST
-/venv
-/enumfields.db
-
-/tests/test.db
+/venv*
+*.db
+*.egg-info
+htmlcov/
+.tox/
+.coverage
+.cache
+.idea

--- a/enumfields/compat.py
+++ b/enumfields/compat.py
@@ -48,3 +48,19 @@ def formfield(db_field, form_class=None, choices_form_class=None, **kwargs):
     if form_class is None:
         form_class = CharField
     return form_class(**defaults)
+
+# This is a bare-bones implementation of `import_string`, as
+# implemented in Django commit f95122e541df5bebb9b5ebb6226b0013e5edc893.
+
+try:
+    try:
+        from django.utils.module_loading import import_string
+    except ImportError:
+        from django.utils.module_loading import import_by_path as import_string
+except ImportError:
+    from django.utils.importlib import import_module
+    def import_string(dotted_path):
+        module_path, class_name = dotted_path.rsplit('.', 1)
+        module = import_module(module_path)
+        return getattr(module, class_name)
+

--- a/enumfields/compat.py
+++ b/enumfields/compat.py
@@ -1,0 +1,50 @@
+# -- encoding: UTF-8 --
+from django.forms import TypedChoiceField, CharField
+from django.utils.text import capfirst
+
+__all__ = ["formfield"]
+
+# This is a copy of Django 1.8's (78d43a5e1064b63db1c486516c4263ef1c4c975c)
+# `Field.formfield()`, for compatibility with Django 1.5.x, which does not
+# support `choices_form_class` in a sane way.
+# The commit b6f4a92ff45d98a63dc29402d8ad86b88e6a6697
+# would make this compatible with our enums,
+# but it's best to go all the way to the freshest code, I think.
+
+def formfield(db_field, form_class=None, choices_form_class=None, **kwargs):
+    """
+    Returns a django.forms.Field instance for this database Field.
+    """
+    defaults = {'required': not db_field.blank,
+                'label': capfirst(db_field.verbose_name),
+                'help_text': db_field.help_text}
+    if db_field.has_default():
+        if callable(db_field.default):
+            defaults['initial'] = db_field.default
+            defaults['show_hidden_initial'] = True
+        else:
+            defaults['initial'] = db_field.get_default()
+    if db_field.choices:
+        # Fields with choices get special treatment.
+        include_blank = (db_field.blank or
+                         not (db_field.has_default() or 'initial' in kwargs))
+        defaults['choices'] = db_field.get_choices(include_blank=include_blank)
+        defaults['coerce'] = db_field.to_python
+        if db_field.null:
+            defaults['empty_value'] = None
+        if choices_form_class is not None:
+            form_class = choices_form_class
+        else:
+            form_class = TypedChoiceField
+        # Many of the subclass-specific formfield arguments (min_value,
+        # max_value) don't apply for choice fields, so be sure to only pass
+        # the values that TypedChoiceField will understand.
+        for k in list(kwargs):
+            if k not in ('coerce', 'empty_value', 'choices', 'required',
+                         'widget', 'label', 'initial', 'help_text',
+                         'error_messages', 'show_hidden_initial'):
+                del kwargs[k]
+    defaults.update(kwargs)
+    if form_class is None:
+        form_class = CharField
+    return form_class(**defaults)

--- a/enumfields/fields.py
+++ b/enumfields/fields.py
@@ -6,11 +6,7 @@ from .forms import EnumChoiceField
 import six
 from django.db.models.fields import NOT_PROVIDED, BLANK_CHOICE_DASH
 
-try:
-    from django.utils.module_loading import import_string
-except ImportError:
-    from django.utils.module_loading import import_by_path as import_string
-
+from .compat import import_string
 
 class EnumFieldMixin(six.with_metaclass(models.SubfieldBase)):
     def __init__(self, enum, **options):

--- a/enumfields/fields.py
+++ b/enumfields/fields.py
@@ -31,7 +31,7 @@ class EnumFieldMixin(six.with_metaclass(models.SubfieldBase)):
                 return value
             if value == m.value or str(value) == str(m.value) or str(value) == str(m):
                 return m
-        raise ValidationError('%s is not a valid value for enum %s' % (value, self.enum))
+        raise ValidationError('%s is not a valid value for enum %s' % (value, self.enum), code="invalid_enum_value")
 
     def get_prep_value(self, value):
         return None if value is None else value.value

--- a/enumfields/fields.py
+++ b/enumfields/fields.py
@@ -1,3 +1,4 @@
+import django
 from django.core.exceptions import ValidationError
 from django.db import models
 from enum import Enum
@@ -80,6 +81,14 @@ class EnumFieldMixin(six.with_metaclass(models.SubfieldBase)):
     def formfield(self, form_class=None, choices_form_class=None, **kwargs):
         if not choices_form_class:
             choices_form_class = EnumChoiceField
+
+        if django.VERSION < (1, 6):
+            # Use a better-compatible implementation of `formfield` for old versions of Django.
+            # It's unfortunate that we need to do this, but since the project supports Django 1.5,
+            # we have to do it.
+            from .compat import formfield
+            return formfield(db_field=self, form_class=form_class, choices_form_class=choices_form_class, **kwargs)
+
         return super(EnumFieldMixin, self).formfield(form_class=form_class, choices_form_class=choices_form_class, **kwargs)
 
 

--- a/enumfields/fields.py
+++ b/enumfields/fields.py
@@ -1,6 +1,7 @@
 from django.core.exceptions import ValidationError
 from django.db import models
 from enum import Enum
+from .forms import EnumChoiceField
 import six
 from django.db.models.fields import NOT_PROVIDED, BLANK_CHOICE_DASH
 
@@ -75,6 +76,11 @@ class EnumFieldMixin(six.with_metaclass(models.SubfieldBase)):
             for (i, display)
             in super(EnumFieldMixin, self).get_choices(include_blank, blank_choice)
         ]
+
+    def formfield(self, form_class=None, choices_form_class=None, **kwargs):
+        if not choices_form_class:
+            choices_form_class = EnumChoiceField
+        return super(EnumFieldMixin, self).formfield(form_class=form_class, choices_form_class=choices_form_class, **kwargs)
 
 
 class EnumField(EnumFieldMixin, models.CharField):

--- a/enumfields/forms.py
+++ b/enumfields/forms.py
@@ -1,0 +1,29 @@
+# -- encoding: UTF-8 --
+from django.forms import TypedChoiceField
+from django.forms.fields import TypedMultipleChoiceField
+from django.utils.encoding import force_text
+
+__all__ = ["EnumChoiceField", "EnumMultipleChoiceField"]
+
+class EnumChoiceFieldMixin(object):
+    def prepare_value(self, value):
+        # Widgets expect to get strings as values.
+
+        if value is None:
+            return ''
+        if hasattr(value, "value"):
+            value = value.value
+        return force_text(value)
+
+    def valid_value(self, value):
+        if hasattr(value, "value"):  # Try validation using the enum value first.
+            if super(EnumChoiceFieldMixin, self).valid_value(value.value):
+                return True
+        return super(EnumChoiceFieldMixin, self).valid_value(value)
+
+
+class EnumChoiceField(EnumChoiceFieldMixin, TypedChoiceField):
+    pass
+
+class EnumMultipleChoiceField(EnumChoiceFieldMixin, TypedMultipleChoiceField):
+    pass

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ except ImportError:
 
 setup(
     name='django-enumfields',
-    version='0.7.0',
+    version='0.7.1',
     author='HZDG',
     author_email='webmaster@hzdg.com',
     description='Real Python Enums for Django.',

--- a/tests/test_django_admin.py
+++ b/tests/test_django_admin.py
@@ -2,7 +2,12 @@
 
 import uuid
 
-from django.contrib.auth import get_user_model
+try:
+    from django.contrib.auth import get_user_model
+except ImportError:  # `get_user_model` only exists from Django 1.5 on.
+    from django.contrib.auth.models import User
+    get_user_model = lambda: User
+
 from django.core.urlresolvers import reverse
 from django.test import Client
 import pytest

--- a/tests/test_django_models.py
+++ b/tests/test_django_models.py
@@ -34,3 +34,13 @@ def test_zero_enum_loads():
 
     m = MyModel.objects.get(id=m.id)
     assert m.zero_field == MyModel.ZeroEnum.ZERO
+
+
+def test_serialization():
+    from django.core.serializers.python import Serializer as PythonSerializer
+    m = MyModel(color=MyModel.Color.RED, taste=MyModel.Taste.SALTY)
+    ser = PythonSerializer()
+    ser.serialize([m])
+    fields = ser.getvalue()[0]["fields"]
+    assert fields["color"] == m.color.value
+    assert fields["taste"] == m.taste.value

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,28 +1,31 @@
 # -- encoding: UTF-8 --
+from django.core.exceptions import ValidationError
 
 from django.forms import BaseForm
 from django.utils.translation import ugettext_lazy
 from enumfields import Enum, EnumField
+import pytest
 import six
+from six import u
 
 
 class Color(Enum):
     __order__ = 'RED GREEN BLUE'
 
-    GREEN = 'g'
     RED = 'r'
+    GREEN = 'g'
     BLUE = 'b'
 
     class Labels:
         RED = 'Reddish'
-        BLUE = ugettext_lazy(u'bluë')
+        BLUE = ugettext_lazy(u('bluë'))
 
 
 def test_choice_ordering():
     EXPECTED_CHOICES = (
         ('r', 'Reddish'),
         ('g', 'Green'),
-        ('b', u'bluë'),
+        ('b', u('bluë')),
     )
     for ((ex_key, ex_val), (key, val)) in zip(EXPECTED_CHOICES, Color.choices()):
         assert key == ex_key
@@ -41,7 +44,7 @@ def test_automatic_labels():
 def test_lazy_labels():
     # Lazy label
     assert isinstance(six.text_type(Color.BLUE), six.string_types)
-    assert six.text_type(Color.BLUE) == u'bluë'
+    assert six.text_type(Color.BLUE) == u('bluë')
 
 def test_formfield_labels():
     # Formfield choice label
@@ -58,3 +61,11 @@ def test_formfield_functionality():
     form = form_cls(data={"color": "r"})
     assert not form.errors
     assert form.cleaned_data["color"] == Color.RED
+
+def test_invalid_to_python_fails():
+    with pytest.raises(ValidationError) as ve:
+        EnumField(Color).to_python("invalid")
+    assert ve.value.code == "invalid_enum_value"
+
+def test_import_by_string():
+    assert EnumField("tests.test_enums.Color").enum == Color

--- a/tests/test_form_fields.py
+++ b/tests/test_form_fields.py
@@ -1,0 +1,24 @@
+# -- encoding: UTF-8 --
+
+from django.forms.models import modelform_factory
+import pytest
+from .models import MyModel
+import six
+
+
+def get_form(**kwargs):
+    instance = MyModel(color=MyModel.Color.RED)
+    FormClass = modelform_factory(MyModel, fields=("color",))
+    return FormClass(instance=instance, **kwargs)
+
+
+@pytest.mark.django_db
+def test_unbound_form_with_instance():
+    form = get_form()
+    assert 'value="r" selected="selected"' in six.text_type(form["color"])
+
+
+@pytest.mark.django_db
+def test_bound_form_with_instance():
+    form = get_form(data={"color": "g"})
+    assert 'value="g" selected="selected"' in six.text_type(form["color"])


### PR DESCRIPTION
Well, damnit.

Looks like my fancy patch broke loading enum values from instances from `ModelForm`s; there wasn't a valid test for it either.

Now there's a fix and while at it, I improved test coverage in general.