### PR TITLE
fixed south migrations for the case default=None

### DIFF
--- a/enumfields/fields.py
+++ b/enumfields/fields.py
@@ -126,7 +126,14 @@ def converter_func(enum_class):
 
 
 def enum_value(an_enum):
-    return an_enum.value
+    if an_enum is None:
+        return None
+
+    if isinstance(an_enum, Enum):
+        return an_enum.value
+
+    raise ValueError("%s is not a enum" % an_enum)
+
 
 
 rules = [


### PR DESCRIPTION
When you create something like:
...
enum_attr = EnumIntegerField(MegaEnum, null=True, blank=True, *default=None*)
...
the None value is provided to enum_value(_) function which tries to do None.value which results in error.
This update fixes it.