### PR TITLE
Fixed get_prep_value bug: 'str' object has no attribute 'value'

### DIFF
--- a/enumfields/fields.py
+++ b/enumfields/fields.py
@@ -32,7 +32,7 @@ class EnumFieldMixin(six.with_metaclass(models.SubfieldBase)):
         raise ValidationError('%s is not a valid value for enum %s' % (value, self.enum), code="invalid_enum_value")
 
     def get_prep_value(self, value):
-        return None if value is None else value.value
+        return None if value is None else value
 
     def value_to_string(self, obj):
         """


### PR DESCRIPTION
Found this error during filtering in django admin