### PR TITLE
fix value returned for integer enum field, actually return the enum instead of int

### DIFF
--- a/enumfields/fields.py
+++ b/enumfields/fields.py
@@ -26,7 +26,7 @@ class EnumFieldMixin(six.with_metaclass(models.SubfieldBase)):
             return None
         for m in self.enum:
             if value == m:
-                return value
+                return m
             if value == m.value or str(value) == str(m.value) or str(value) == str(m):
                 return m
         raise ValidationError('%s is not a valid value for enum %s' % (value, self.enum), code="invalid_enum_value")

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,5 +1,6 @@
 from django.db import models
-from enum import Enum
+from enum import Enum, IntEnum
+
 from enumfields import EnumField, EnumIntegerField
 
 
@@ -22,6 +23,10 @@ class MyModel(models.Model):
         ZERO = 0
         ONE = 1
 
+    class IntegerEnum(IntEnum):
+        A = 0
+        B = 1
+
     taste = EnumField(Taste, default=Taste.SWEET)
     taste_null_default = EnumField(Taste, null=True, blank=True, default=None)
     taste_int = EnumIntegerField(Taste, default=Taste.SWEET)
@@ -32,3 +37,4 @@ class MyModel(models.Model):
     random_code = models.TextField(null=True, blank=True)
 
     zero_field = EnumIntegerField(ZeroEnum, null=True, default=None, blank=True)
+    int_enum = EnumIntegerField(IntegerEnum, null=True, default=None, blank=True)

--- a/tests/test_django_models.py
+++ b/tests/test_django_models.py
@@ -1,7 +1,9 @@
 # -- encoding: UTF-8 --
 
-from django.db import connection
 import pytest
+from django.db import connection
+from enum import IntEnum
+
 from .models import MyModel
 
 
@@ -59,6 +61,16 @@ def test_zero_enum_loads():
 
     m = MyModel.objects.get(id=m.id)
     assert m.zero_field == MyModel.ZeroEnum.ZERO
+
+
+@pytest.mark.django_db
+def test_int_enum():
+    m = MyModel(int_enum=MyModel.IntegerEnum.A, color=MyModel.Color.RED)
+    m.save()
+
+    m = MyModel.objects.get(id=m.id)
+    assert m.int_enum == MyModel.IntegerEnum.A
+    assert isinstance(m.int_enum, MyModel.IntegerEnum)
 
 
 def test_serialization():


### PR DESCRIPTION
this fails if you use an int enum, with an integer enum field, since value and m are equivalent, return m instead