### PR TITLE
Don't mangle values when they're already enums.

### DIFF
--- a/enumfields/fields.py
+++ b/enumfields/fields.py
@@ -24,6 +24,8 @@ class EnumFieldMixin(six.with_metaclass(models.SubfieldBase)):
     def to_python(self, value):
         if value is None or value == '':
             return None
+        if isinstance(value, self.enum):
+            return value
         for m in self.enum:
             if value == m:
                 return m

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from enum import Enum, IntEnum
 
+import enumfields
 from enumfields import EnumField, EnumIntegerField
 
 
@@ -27,6 +28,17 @@ class MyModel(models.Model):
         A = 0
         B = 1
 
+    class LabeledEnum(enumfields.Enum):
+        FOO = 'foo'
+        BAR = 'bar'
+        FOOBAR = 'foobar'
+
+        class Labels:
+            FOO = 'Foo'
+            BAR = 'Bar'
+            # this is intentional. see test_nonunique_label
+            FOOBAR = 'Foo'
+
     taste = EnumField(Taste, default=Taste.SWEET)
     taste_null_default = EnumField(Taste, null=True, blank=True, default=None)
     taste_int = EnumIntegerField(Taste, default=Taste.SWEET)
@@ -38,3 +50,5 @@ class MyModel(models.Model):
 
     zero_field = EnumIntegerField(ZeroEnum, null=True, default=None, blank=True)
     int_enum = EnumIntegerField(IntegerEnum, null=True, default=None, blank=True)
+
+    labeled_enum = EnumField(LabeledEnum, blank=True, null=True)

--- a/tests/test_django_models.py
+++ b/tests/test_django_models.py
@@ -81,3 +81,9 @@ def test_serialization():
     fields = ser.getvalue()[0]["fields"]
     assert fields["color"] == m.color.value
     assert fields["taste"] == m.taste.value
+
+
+def test_nonunique_label():
+    obj = MyModel(labeled_enum=MyModel.LabeledEnum.FOOBAR)
+
+    assert obj.labeled_enum is MyModel.LabeledEnum.FOOBAR


### PR DESCRIPTION
This breaks when you have two enum values with the same label.