### PR TITLE
support enum values in EnumFieldMixin.get_prep_value

### DIFF
--- a/enumfields/fields.py
+++ b/enumfields/fields.py
@@ -32,7 +32,7 @@ class EnumFieldMixin(six.with_metaclass(models.SubfieldBase)):
         raise ValidationError('%s is not a valid value for enum %s' % (value, self.enum), code="invalid_enum_value")
 
     def get_prep_value(self, value):
-        return None if value is None else value.value
+        return None if value is None else self.enum(value).value
 
     def value_to_string(self, obj):
         """

--- a/tests/test_django_models.py
+++ b/tests/test_django_models.py
@@ -16,6 +16,14 @@ def test_field_value():
     m = MyModel.objects.filter(color=MyModel.Color.RED)[0]
     assert m.color == MyModel.Color.RED
 
+    # Passing the value should work the same way as passing the enum
+    assert MyModel.Color.RED.value == 'r'
+    m = MyModel.objects.filter(color='r')[0]
+    assert m.color == MyModel.Color.RED
+
+    with pytest.raises(ValueError):
+        MyModel.objects.filter(color='xx')[0]
+
 
 @pytest.mark.django_db
 def test_db_value():


### PR DESCRIPTION
Currently if you try `MyModel.objects.filter(color='r')` you will get an error similar to `str object has no attributes value`. This PR adds the support for `MyModel.objects.filter(color='r')` where `r` is equal to the value of `MyModel.Color.RED`.

This is useful in the django shell to use as a shortcut but also when working with other libraries that are not aware of the `EnumField` (for instance django-rest-framework filters).
