### PR TITLE
update tox.ini to add support for python 3.5 and django 1.9

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,26 +1,38 @@
 [tox]
 envlist =
-    python34-django17, python34-django16, python34-django15,
-    python33-django17, python33-django16, python33-django15,
-    python32-django17, python32-django16, python32-django15,
-    python27-django17, python27-django16, python27-django15, python27-django14,
-    python26-django14,
+    python35-django19, python35-django18
+    python34-django19, python34-django18, python34-django17
+    python33-django18, python33-django17, python33-django16
+    python27-django19, python27-django18, python27-django17, python27-django16, python27-django15, python27-django14,
+    python26-django16, python26-django15, python26-django14,
 
 [testenv]
 setenv = PYTHONPATH = {toxinidir}
 commands = python setup.py test
 
+[testenv:python35-django19]
+basepython = python3.5
+deps = Django>=1.9,<1.10
+
+[testenv:python35-django18]
+basepython = python3.5
+deps = Django>=1.8,<1.9
+
+[testenv:python34-django19]
+basepython = python3.4
+deps = Django>=1.9,<1.10
+
+[testenv:python34-django18]
+basepython = python3.4
+deps = Django>=1.8,<1.9
+
 [testenv:python34-django17]
 basepython = python3.4
 deps = Django>=1.7,<1.8
 
-[testenv:python34-django16]
-basepython = python3.4
-deps = Django>=1.6,<1.7
-
-[testenv:python34-django15]
-basepython = python3.4
-deps = Django>=1.5,<1.6
+[testenv:python33-django18]
+basepython = python3.3
+deps = Django>=1.8,<1.9
 
 [testenv:python33-django17]
 basepython = python3.3
@@ -30,21 +42,13 @@ deps = Django>=1.7,<1.8
 basepython = python3.3
 deps = Django>=1.6,<1.7
 
-[testenv:python33-django15]
-basepython = python3.3
-deps = Django>=1.5,<1.6
+[testenv:python27-django19]
+basepython = python2.7
+deps = Django>=1.9,<1.10
 
-[testenv:python32-django17]
-basepython = python3.2
-deps = Django>=1.7,<1.8
-
-[testenv:python32-django16]
-basepython = python3.2
-deps = Django>=1.6,<1.7
-
-[testenv:python32-django15]
-basepython = python3.2
-deps = Django>=1.5,<1.6
+[testenv:python27-django18]
+basepython = python2.7
+deps = Django>=1.8,<1.9
 
 [testenv:python27-django17]
 basepython = python2.7
@@ -61,6 +65,14 @@ deps = Django>=1.5,<1.6
 [testenv:python27-django14]
 basepython = python2.7
 deps = Django>=1.4,<1.5
+
+[testenv:python26-django16]
+basepython = python2.6
+deps = Django>=1.6,<1.7
+
+[testenv:python26-django15]
+basepython = python2.6
+deps = Django>=1.5,<1.6
 
 [testenv:python26-django14]
 basepython = python2.6


### PR DESCRIPTION
Adding support for python 3.5 and django 1.9. This comes along with dropping support for python 3.2. The current version of virtualenv does not support py32. https://github.com/travis-ci/travis-ci/issues/5485

I updated the list of versions according to django's documentation (excluding python 3.2)
https://docs.djangoproject.com/en/1.9/faq/install/#what-python-version-can-i-use-with-django & https://docs.djangoproject.com/en/1.7/faq/install/#what-python-version-can-i-use-with-django

I did not add support for django 1.10 since it is under development and django 1.9 gives a deprecation warning `RemovedInDjango110Warning: SubfieldBase has been deprecated. Use Field.from_db_value instead.` See also https://github.com/hzdg/django-enumfields/issues/45