### PR TITLE
Remove SubfieldBase metaclass from EnumFieldMixin

### DIFF
--- a/enumfields/fields.py
+++ b/enumfields/fields.py
@@ -32,7 +32,7 @@ class EnumFieldMixin(six.with_metaclass(models.SubfieldBase)):
         raise ValidationError('%s is not a valid value for enum %s' % (value, self.enum), code="invalid_enum_value")
 
     def get_prep_value(self, value):
-        return None if value is None else value.value
+        return None if value is None else self.enum(value).value
 
     def value_to_string(self, obj):
         """

--- a/enumfields/fields.py
+++ b/enumfields/fields.py
@@ -9,7 +9,9 @@ from django.db.models.fields import NOT_PROVIDED, BLANK_CHOICE_DASH
 
 from .compat import import_string
 
-class EnumFieldMixin(six.with_metaclass(models.SubfieldBase)):
+metaclass = models.SubfieldBase if django.VERSION < (1, 8) else type
+
+class EnumFieldMixin(six.with_metaclass(metaclass)):
     def __init__(self, enum, **options):
         if isinstance(enum, six.string_types):
             self.enum = import_string(enum)
@@ -33,6 +35,9 @@ class EnumFieldMixin(six.with_metaclass(models.SubfieldBase)):
 
     def get_prep_value(self, value):
         return None if value is None else self.enum(value).value
+
+    def from_db_value(self, value, expression, connection, context):
+        return self.to_python(value)
 
     def value_to_string(self, obj):
         """

--- a/tests/test_django_models.py
+++ b/tests/test_django_models.py
@@ -16,6 +16,14 @@ def test_field_value():
     m = MyModel.objects.filter(color=MyModel.Color.RED)[0]
     assert m.color == MyModel.Color.RED
 
+    # Passing the value should work the same way as passing the enum
+    assert MyModel.Color.RED.value == 'r'
+    m = MyModel.objects.filter(color='r')[0]
+    assert m.color == MyModel.Color.RED
+
+    with pytest.raises(ValueError):
+        MyModel.objects.filter(color='xx')[0]
+
 
 @pytest.mark.django_db
 def test_db_value():

--- a/tox.ini
+++ b/tox.ini
@@ -1,26 +1,38 @@
 [tox]
 envlist =
-    python34-django17, python34-django16, python34-django15,
-    python33-django17, python33-django16, python33-django15,
-    python32-django17, python32-django16, python32-django15,
-    python27-django17, python27-django16, python27-django15, python27-django14,
-    python26-django14,
+    python35-django19, python35-django18
+    python34-django19, python34-django18, python34-django17
+    python33-django18, python33-django17, python33-django16
+    python27-django19, python27-django18, python27-django17, python27-django16, python27-django15, python27-django14,
+    python26-django16, python26-django15, python26-django14,
 
 [testenv]
 setenv = PYTHONPATH = {toxinidir}
 commands = python setup.py test
 
+[testenv:python35-django19]
+basepython = python3.5
+deps = Django>=1.9,<1.10
+
+[testenv:python35-django18]
+basepython = python3.5
+deps = Django>=1.8,<1.9
+
+[testenv:python34-django19]
+basepython = python3.4
+deps = Django>=1.9,<1.10
+
+[testenv:python34-django18]
+basepython = python3.4
+deps = Django>=1.8,<1.9
+
 [testenv:python34-django17]
 basepython = python3.4
 deps = Django>=1.7,<1.8
 
-[testenv:python34-django16]
-basepython = python3.4
-deps = Django>=1.6,<1.7
-
-[testenv:python34-django15]
-basepython = python3.4
-deps = Django>=1.5,<1.6
+[testenv:python33-django18]
+basepython = python3.3
+deps = Django>=1.8,<1.9
 
 [testenv:python33-django17]
 basepython = python3.3
@@ -30,21 +42,13 @@ deps = Django>=1.7,<1.8
 basepython = python3.3
 deps = Django>=1.6,<1.7
 
-[testenv:python33-django15]
-basepython = python3.3
-deps = Django>=1.5,<1.6
+[testenv:python27-django19]
+basepython = python2.7
+deps = Django>=1.9,<1.10
 
-[testenv:python32-django17]
-basepython = python3.2
-deps = Django>=1.7,<1.8
-
-[testenv:python32-django16]
-basepython = python3.2
-deps = Django>=1.6,<1.7
-
-[testenv:python32-django15]
-basepython = python3.2
-deps = Django>=1.5,<1.6
+[testenv:python27-django18]
+basepython = python2.7
+deps = Django>=1.8,<1.9
 
 [testenv:python27-django17]
 basepython = python2.7
@@ -61,6 +65,14 @@ deps = Django>=1.5,<1.6
 [testenv:python27-django14]
 basepython = python2.7
 deps = Django>=1.4,<1.5
+
+[testenv:python26-django16]
+basepython = python2.6
+deps = Django>=1.6,<1.7
+
+[testenv:python26-django15]
+basepython = python2.6
+deps = Django>=1.5,<1.6
 
 [testenv:python26-django14]
 basepython = python2.6


### PR DESCRIPTION
Deprecated in Django 1.8, see release notes:
https://docs.djangoproject.com/en/1.8/releases/1.8/#subfieldbase

fixes #45