### PR TITLE
Simplify Tox configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ htmlcov/
 .coverage
 .cache
 .idea
+.eggs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
+sudo: false
 language: python
 python:
+  - 2.6
   - 2.7
-install: pip install tox --use-mirrors
+  - 3.3
+  - 3.4
+  - 3.5
+install:
+  - pip install -U pip wheel setuptools
+  - pip install tox tox-travis
 script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -4,76 +4,29 @@ envlist =
     python34-django19, python34-django18, python34-django17
     python33-django18, python33-django17, python33-django16
     python27-django19, python27-django18, python27-django17, python27-django16, python27-django15, python27-django14,
-    python26-django16, python26-django15, python26-django14,
+    python26-django16, python26-django15, python26-django14
+
+[tox:travis]
+2.6 = python26
+2.7 = python27
+3.3 = python33
+3.4 = python34
+3.5 = python35
 
 [testenv]
 setenv = PYTHONPATH = {toxinidir}
 commands = python setup.py test
-
-[testenv:python35-django19]
-basepython = python3.5
-deps = Django>=1.9,<1.10
-
-[testenv:python35-django18]
-basepython = python3.5
-deps = Django>=1.8,<1.9
-
-[testenv:python34-django19]
-basepython = python3.4
-deps = Django>=1.9,<1.10
-
-[testenv:python34-django18]
-basepython = python3.4
-deps = Django>=1.8,<1.9
-
-[testenv:python34-django17]
-basepython = python3.4
-deps = Django>=1.7,<1.8
-
-[testenv:python33-django18]
-basepython = python3.3
-deps = Django>=1.8,<1.9
-
-[testenv:python33-django17]
-basepython = python3.3
-deps = Django>=1.7,<1.8
-
-[testenv:python33-django16]
-basepython = python3.3
-deps = Django>=1.6,<1.7
-
-[testenv:python27-django19]
-basepython = python2.7
-deps = Django>=1.9,<1.10
-
-[testenv:python27-django18]
-basepython = python2.7
-deps = Django>=1.8,<1.9
-
-[testenv:python27-django17]
-basepython = python2.7
-deps = Django>=1.7,<1.8
-
-[testenv:python27-django16]
-basepython = python2.7
-deps = Django>=1.6,<1.7
-
-[testenv:python27-django15]
-basepython = python2.7
-deps = Django>=1.5,<1.6
-
-[testenv:python27-django14]
-basepython = python2.7
-deps = Django>=1.4,<1.5
-
-[testenv:python26-django16]
-basepython = python2.6
-deps = Django>=1.6,<1.7
-
-[testenv:python26-django15]
-basepython = python2.6
-deps = Django>=1.5,<1.6
-
-[testenv:python26-django14]
-basepython = python2.6
-deps = Django>=1.4,<1.5
+basepython =
+    python26: python2.6
+    python27: python2.7
+    python33: python3.3
+    python34: python3.4
+    python35: python3.5
+deps =
+    django14: Django>=1.4,<1.5
+    django15: Django>=1.5,<1.6
+    django16: Django>=1.6,<1.7
+    django17: Django>=1.7,<1.8
+    django18: Django>=1.8,<1.9
+    # can't use <1.10 since 1.10a1 is out and that would match :(
+    django19: Django>=1.9,<=1.9.7


### PR DESCRIPTION
* Use Tox's factor-conditional settings for a DRYer tox.ini
* ⚠️ Also drop test support for Python 3.2, as pip no longer supports 3.0 to 3.2 either
* Use tox-travis for build parallelization on Travis