### PR TITLE
Don't nest enum classes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,12 +22,12 @@ EnumField, EnumIntegerField
     from enumfields import EnumField
     from enumfields import Enum  # Uses Ethan Furman's "enum34" backport
 
-    class MyModel(models.Model):
+    class Color(Enum):
+        RED = 'r'
+        GREEN = 'g'
+        BLUE = 'b'
 
-        class Color(Enum):
-            RED = 'r'
-            GREEN = 'g'
-            BLUE = 'b'
+    class MyModel(models.Model):
 
         color = EnumField(Color, max_length=1)
 
@@ -35,7 +35,7 @@ Elsewhere:
 
 .. code-block:: python
 
-    m = MyModel.objects.filter(color=MyModel.Color.RED)
+    m = MyModel.objects.filter(color=Color.RED)
 
 ``EnumIntegerField`` works identically, but the underlying storage mechanism is
 an ``IntegerField`` instead of a ``CharField``.
@@ -54,20 +54,19 @@ names. You can provide custom labels with a nested "Labels" class.
 
     from enumfields import EnumField, Enum  # Our own Enum class
 
+    class Color(Enum):
+        RED = 'r'
+        GREEN = 'g'
+        BLUE = 'b'
+
+        class Labels:
+            RED = 'A custom label'
+
     class MyModel(models.Model):
-
-        class Color(Enum):
-            RED = 'r'
-            GREEN = 'g'
-            BLUE = 'b'
-
-            class Labels:
-                RED = 'A custom label'
-
         color = EnumField(Color, max_length=1)
 
-    assert MyModel.Color.GREEN.label == 'Green'
-    assert MyModel.Color.RED.label == 'A custom label'
+    assert Color.GREEN.label == 'Green'
+    assert Color.RED.label == 'A custom label'
 
 
 .. _PEP435: http://www.python.org/dev/peps/pep-0435/

--- a/tests/enums.py
+++ b/tests/enums.py
@@ -1,0 +1,50 @@
+# coding=utf-8
+from __future__ import unicode_literals
+from django.utils.translation import ugettext_lazy
+
+from enumfields import Enum, IntEnum
+
+
+class Color(Enum):
+    __order__ = 'RED GREEN BLUE'
+
+    RED = 'r'
+    GREEN = 'g'
+    BLUE = 'b'
+
+    class Labels:
+        RED = 'Reddish'
+        BLUE = ugettext_lazy('bluë')
+
+
+class Taste(Enum):
+    SWEET = 1
+    SOUR = 2
+    BITTER = 3
+    SALTY = 4
+    UMAMI = 5
+
+
+class ZeroEnum(Enum):
+    ZERO = 0
+    ONE = 1
+
+
+class IntegerEnum(IntEnum):
+    A = 0
+    B = 1
+
+    class Labels:
+        A = 'foo'
+
+
+class LabeledEnum(Enum):
+    FOO = 'foo'
+    BAR = 'bar'
+    FOOBAR = 'foobar'
+
+    class Labels:
+        FOO = 'Foo'
+        BAR = 'Bar'
+        # this is intentional. see test_nonunique_label
+        FOOBAR = 'Foo'

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,44 +1,11 @@
 from django.db import models
 
-from enumfields import Enum, IntEnum, EnumField, EnumIntegerField
+from enumfields import EnumField, EnumIntegerField
+from .enums import Color, Taste, IntegerEnum, LabeledEnum, ZeroEnum
 
 
 class MyModel(models.Model):
-    class Color(Enum):
-        RED = 'r'
-        GREEN = 'g'
-        BLUE = 'b'
-
     color = EnumField(Color, max_length=1)
-
-    class Taste(Enum):
-        SWEET = 1
-        SOUR = 2
-        BITTER = 3
-        SALTY = 4
-        UMAMI = 5
-
-    class ZeroEnum(Enum):
-        ZERO = 0
-        ONE = 1
-
-    class IntegerEnum(IntEnum):
-        A = 0
-        B = 1
-        class Labels:
-            A = 'foo'
-
-    class LabeledEnum(Enum):
-        FOO = 'foo'
-        BAR = 'bar'
-        FOOBAR = 'foobar'
-
-        class Labels:
-            FOO = 'Foo'
-            BAR = 'Bar'
-            # this is intentional. see test_nonunique_label
-            FOOBAR = 'Foo'
-
     taste = EnumField(Taste, default=Taste.SWEET)
     taste_null_default = EnumField(Taste, null=True, blank=True, default=None)
     taste_int = EnumIntegerField(Taste, default=Taste.SWEET)

--- a/tests/test_django_admin.py
+++ b/tests/test_django_admin.py
@@ -13,6 +13,7 @@ from django.core.urlresolvers import reverse
 from django.test import Client
 import pytest
 from enumfields import EnumIntegerField
+from .enums import Color, Taste, ZeroEnum, IntegerEnum
 from .models import MyModel
 
 
@@ -46,11 +47,11 @@ def test_model_admin_post(superuser_client):
     url = reverse("admin:tests_mymodel_add")
     secret_uuid = str(uuid.uuid4())
     post_data = {
-        'color': MyModel.Color.RED.value,
-        'taste': MyModel.Taste.UMAMI.value,
-        'taste_int': MyModel.Taste.SWEET.value,
+        'color': Color.RED.value,
+        'taste': Taste.UMAMI.value,
+        'taste_int': Taste.SWEET.value,
         'random_code': secret_uuid,
-        'zero2': MyModel.ZeroEnum.ZERO.value,
+        'zero2': ZeroEnum.ZERO.value,
     }
     response = superuser_client.post(url, follow=True, data=post_data)
     response.render()
@@ -60,29 +61,29 @@ def test_model_admin_post(superuser_client):
     assert b"Select a valid choice" not in text
     try:
         inst = MyModel.objects.get(random_code=secret_uuid)
-    except MyModel.DoesNotExist:
+    except DoesNotExist:
         assert False, "Object wasn't created in the database"
-    assert inst.color == MyModel.Color.RED, "Redness not assured"
-    assert inst.taste == MyModel.Taste.UMAMI, "Umami not there"
-    assert inst.taste_int == MyModel.Taste.SWEET, "Not sweet enough"
+    assert inst.color == Color.RED, "Redness not assured"
+    assert inst.taste == Taste.UMAMI, "Umami not there"
+    assert inst.taste_int == Taste.SWEET, "Not sweet enough"
 
 
 @pytest.mark.django_db
 @pytest.mark.urls('tests.urls')
-@pytest.mark.parametrize('q_color', (None, MyModel.Color.BLUE, MyModel.Color.RED))
-@pytest.mark.parametrize('q_taste', (None, MyModel.Taste.SWEET, MyModel.Taste.SOUR))
-@pytest.mark.parametrize('q_int_enum', (None, MyModel.IntegerEnum.A, MyModel.IntegerEnum.B))
+@pytest.mark.parametrize('q_color', (None, Color.BLUE, Color.RED))
+@pytest.mark.parametrize('q_taste', (None, Taste.SWEET, Taste.SOUR))
+@pytest.mark.parametrize('q_int_enum', (None, IntegerEnum.A, IntegerEnum.B))
 def test_model_admin_filter(superuser_client, q_color, q_taste, q_int_enum):
     """
     Test that various combinations of Enum filters seem to do the right thing in the change list.
     """
 
     # Create a bunch of objects...
-    MyModel.objects.create(color=MyModel.Color.RED)
-    for taste in MyModel.Taste:
-        MyModel.objects.create(color=MyModel.Color.BLUE, taste=taste)
-    MyModel.objects.create(color=MyModel.Color.BLUE, taste=MyModel.Taste.UMAMI, int_enum=MyModel.IntegerEnum.A)
-    MyModel.objects.create(color=MyModel.Color.GREEN, int_enum=MyModel.IntegerEnum.B)
+    MyModel.objects.create(color=Color.RED)
+    for taste in Taste:
+        MyModel.objects.create(color=Color.BLUE, taste=taste)
+    MyModel.objects.create(color=Color.BLUE, taste=Taste.UMAMI, int_enum=IntegerEnum.A)
+    MyModel.objects.create(color=Color.GREEN, int_enum=IntegerEnum.B)
 
     # Build a Django lookup...
     lookup = dict((k, v) for (k, v) in {
@@ -103,6 +104,6 @@ def test_model_admin_filter(superuser_client, q_color, q_taste, q_int_enum):
 
 
 def test_django_admin_lookup_value_for_integer_enum_field():
-    field = EnumIntegerField(MyModel.Taste)
+    field = EnumIntegerField(Taste)
 
-    assert field.get_prep_value(str(MyModel.Taste.BITTER)) == 3, "get_prep_value should be able to convert from strings"
+    assert field.get_prep_value(str(Taste.BITTER)) == 3, "get_prep_value should be able to convert from strings"

--- a/tests/test_django_models.py
+++ b/tests/test_django_models.py
@@ -4,22 +4,23 @@ import pytest
 from django.db import connection
 from enum import IntEnum
 
+from .enums import Color, IntegerEnum, LabeledEnum, Taste, ZeroEnum
 from .models import MyModel
 
 
 @pytest.mark.django_db
 def test_field_value():
-    m = MyModel(color=MyModel.Color.RED)
+    m = MyModel(color=Color.RED)
     m.save()
-    assert m.color == MyModel.Color.RED
+    assert m.color == Color.RED
 
-    m = MyModel.objects.filter(color=MyModel.Color.RED)[0]
-    assert m.color == MyModel.Color.RED
+    m = MyModel.objects.filter(color=Color.RED)[0]
+    assert m.color == Color.RED
 
     # Passing the value should work the same way as passing the enum
-    assert MyModel.Color.RED.value == 'r'
+    assert Color.RED.value == 'r'
     m = MyModel.objects.filter(color='r')[0]
-    assert m.color == MyModel.Color.RED
+    assert m.color == Color.RED
 
     with pytest.raises(ValueError):
         MyModel.objects.filter(color='xx')[0]
@@ -27,11 +28,11 @@ def test_field_value():
 
 @pytest.mark.django_db
 def test_db_value():
-    m = MyModel(color=MyModel.Color.RED)
+    m = MyModel(color=Color.RED)
     m.save()
     cursor = connection.cursor()
     cursor.execute('SELECT color FROM %s WHERE id = %%s' % MyModel._meta.db_table, [m.pk])
-    assert cursor.fetchone()[0] == MyModel.Color.RED.value
+    assert cursor.fetchone()[0] == Color.RED.value
 
 
 @pytest.mark.django_db
@@ -44,7 +45,7 @@ def test_enum_int_field_validators():
     orig_method = connection.ops.integer_field_range
     connection.ops.integer_field_range = (lambda *args: (-100, 100))
 
-    m = MyModel(color=MyModel.Color.RED)
+    m = MyModel(color=Color.RED)
 
     # Uncache validators property of taste_int
     for f in m._meta.fields:
@@ -62,28 +63,28 @@ def test_enum_int_field_validators():
 @pytest.mark.django_db
 def test_zero_enum_loads():
     # Verifies that we can save and load enums with the value of 0 (zero).
-    m = MyModel(zero_field=MyModel.ZeroEnum.ZERO,
-                color=MyModel.Color.GREEN)
+    m = MyModel(zero_field=ZeroEnum.ZERO,
+                color=Color.GREEN)
     m.save()
-    assert m.zero_field == MyModel.ZeroEnum.ZERO
+    assert m.zero_field == ZeroEnum.ZERO
 
     m = MyModel.objects.get(id=m.id)
-    assert m.zero_field == MyModel.ZeroEnum.ZERO
+    assert m.zero_field == ZeroEnum.ZERO
 
 
 @pytest.mark.django_db
 def test_int_enum():
-    m = MyModel(int_enum=MyModel.IntegerEnum.A, color=MyModel.Color.RED)
+    m = MyModel(int_enum=IntegerEnum.A, color=Color.RED)
     m.save()
 
     m = MyModel.objects.get(id=m.id)
-    assert m.int_enum == MyModel.IntegerEnum.A
-    assert isinstance(m.int_enum, MyModel.IntegerEnum)
+    assert m.int_enum == IntegerEnum.A
+    assert isinstance(m.int_enum, IntegerEnum)
 
 
 def test_serialization():
     from django.core.serializers.python import Serializer as PythonSerializer
-    m = MyModel(color=MyModel.Color.RED, taste=MyModel.Taste.SALTY)
+    m = MyModel(color=Color.RED, taste=Taste.SALTY)
     ser = PythonSerializer()
     ser.serialize([m])
     fields = ser.getvalue()[0]["fields"]
@@ -94,10 +95,10 @@ def test_serialization():
 @pytest.mark.django_db
 def test_nonunique_label():
     obj = MyModel.objects.create(
-        color=MyModel.Color.BLUE,
-        labeled_enum=MyModel.LabeledEnum.FOOBAR
+        color=Color.BLUE,
+        labeled_enum=LabeledEnum.FOOBAR
     )
-    assert obj.labeled_enum is MyModel.LabeledEnum.FOOBAR
+    assert obj.labeled_enum is LabeledEnum.FOOBAR
 
     obj = MyModel.objects.get(pk=obj.pk)
-    assert obj.labeled_enum is MyModel.LabeledEnum.FOOBAR
+    assert obj.labeled_enum is LabeledEnum.FOOBAR

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,33 +1,19 @@
 # -- encoding: UTF-8 --
+from __future__ import unicode_literals
 from django.core.exceptions import ValidationError
 
 from django.forms import BaseForm
-from django.utils.translation import ugettext_lazy
-from enumfields import Enum, EnumField
+from enumfields import EnumField
 import pytest
 import six
-from six import u
 
-from tests.models import MyModel
-
-
-class Color(Enum):
-    __order__ = 'RED GREEN BLUE'
-
-    RED = 'r'
-    GREEN = 'g'
-    BLUE = 'b'
-
-    class Labels:
-        RED = 'Reddish'
-        BLUE = ugettext_lazy(u('bluë'))
-
+from .enums import Color, IntegerEnum
 
 def test_choice_ordering():
     EXPECTED_CHOICES = (
         ('r', 'Reddish'),
         ('g', 'Green'),
-        ('b', u('bluë')),
+        ('b', 'bluë'),
     )
     for ((ex_key, ex_val), (key, val)) in zip(EXPECTED_CHOICES, Color.choices()):
         assert key == ex_key
@@ -37,18 +23,18 @@ def test_custom_labels():
     # Custom label
     assert Color.RED.label == 'Reddish'
     assert six.text_type(Color.RED) == 'Reddish'
-    assert six.text_type(MyModel.IntegerEnum.A) == 'foo'
+    assert six.text_type(IntegerEnum.A) == 'foo'
 
 def test_automatic_labels():
     # Automatic label
     assert Color.GREEN.label == 'Green'
     assert six.text_type(Color.GREEN) == 'Green'
-    assert six.text_type(MyModel.IntegerEnum.B) == 'B'
+    assert six.text_type(IntegerEnum.B) == 'B'
 
 def test_lazy_labels():
     # Lazy label
     assert isinstance(six.text_type(Color.BLUE), six.string_types)
-    assert six.text_type(Color.BLUE) == u('bluë')
+    assert six.text_type(Color.BLUE) == 'bluë'
 
 def test_formfield_labels():
     # Formfield choice label
@@ -59,7 +45,7 @@ def test_formfield_labels():
             assert text == expectations[value]
 
 def test_formfield_functionality():
-    form_cls = type("FauxForm", (BaseForm,), {
+    form_cls = type(str("FauxForm"), (BaseForm,), {
         "base_fields": {"color": EnumField(Color).formfield()}
     })
     form = form_cls(data={"color": "r"})

--- a/tests/test_form_fields.py
+++ b/tests/test_form_fields.py
@@ -2,12 +2,13 @@
 from django.db.models import BLANK_CHOICE_DASH
 from django.forms.models import modelform_factory
 import pytest
+from .enums import Color
 from .models import MyModel
 import six
 
 
 def get_form(**kwargs):
-    instance = MyModel(color=MyModel.Color.RED)
+    instance = MyModel(color=Color.RED)
     FormClass = modelform_factory(MyModel, fields=("color", "zero2", "int_enum"))
     return FormClass(instance=instance, **kwargs)
 


### PR DESCRIPTION
Django can't use nested classes in migrations.

Fixes #57