### PR TITLE
Restore cast-on-assign behavior on Django 1.8+

### DIFF
--- a/tests/test_issue_60.py
+++ b/tests/test_issue_60.py
@@ -1,0 +1,34 @@
+import pytest
+
+from .models import MyModel
+
+try:
+    from .enums import Color  # Use the new location of Color enum
+except ImportError:
+    Color = MyModel.Color  # Attempt the 0.7.4 location of color enum
+
+
+@pytest.mark.django_db
+def test_fields_value_is_enum_when_unsaved():
+    obj = MyModel(color='r')
+    assert Color.RED == obj.color
+
+
+@pytest.mark.django_db
+def test_fields_value_is_enum_when_saved():
+    obj = MyModel(color='r')
+    obj.save()
+    assert Color.RED == obj.color
+
+
+@pytest.mark.django_db
+def test_fields_value_is_enum_when_created():
+    obj = MyModel.objects.create(color='r')
+    assert Color.RED == obj.color
+
+
+@pytest.mark.django_db
+def test_fields_value_is_enum_when_retrieved():
+    MyModel.objects.create(color='r')
+    obj = MyModel.objects.all()[:1][0]  # .first() not available on all Djangoes
+    assert Color.RED == obj.color


### PR DESCRIPTION
Turns out the future-deprecated SubfieldBase class did more than what was initially thought.  Since it is removed in Django 1.10+, for clarity we no longer use it at all.

Instead we intern the behavior of its `Creator` descriptor class as `CastOnAssignDescriptor`.

Fixes #60
Refs https://code.djangoproject.com/ticket/26807
Refs 826005087541805620be3daffab3e8d106eedc2f