### PR TITLE
Django-Rest-Framework support & EnumField improvements

### DIFF
--- a/enumfields/compat.py
+++ b/enumfields/compat.py
@@ -65,3 +65,19 @@ except ImportError:
         module_path, class_name = dotted_path.rsplit('.', 1)
         module = import_module(module_path)
         return getattr(module, class_name)
+
+
+def import_class(components):
+    from importlib import import_module
+
+    if len(components) > 2:
+        raise ValueError('Invalid enum options')
+    elif len(components) == 1:
+        return import_string(components[0])
+    else:
+        module_path, full_class_name = components
+        module = import_module(module_path)
+        current_member = module
+        for class_name in full_class_name.split('.'):
+            current_member = getattr(current_member, class_name)
+        return current_member

--- a/enumfields/drf/__init__.py
+++ b/enumfields/drf/__init__.py
@@ -1,0 +1,2 @@
+from .fields import EnumField
+from .serializers import EnumSupportSerializerMixin

--- a/enumfields/drf/fields.py
+++ b/enumfields/drf/fields.py
@@ -9,7 +9,7 @@ class EnumField(ChoiceField):
         super(EnumField, self).__init__(**kwargs)
 
     def to_representation(self, instance):
-        if instance in ('', None):
+        if instance in ('', u'', None):
             return instance
         try:
             if not isinstance(instance, self.enum):
@@ -20,6 +20,8 @@ class EnumField(ChoiceField):
                 instance, self.enum.__name__))
 
     def to_internal_value(self, data):
+        if isinstance(data, self.enum):
+            return data
         # Let data goes through ChoiceField.to_internal_value first
         # So we don't need to handle int <-> str conversion (DRF behavior)
         cleaned_data = super(EnumField, self).to_internal_value(data)

--- a/enumfields/drf/fields.py
+++ b/enumfields/drf/fields.py
@@ -1,0 +1,29 @@
+from rest_framework.fields import ChoiceField
+
+
+class EnumField(ChoiceField):
+    def __init__(self, enum, **kwargs):
+        self.enum = enum
+        kwargs['choices'] = tuple(
+            (e.value, getattr(e, 'label', e.name)) for e in self.enum)
+        super(EnumField, self).__init__(**kwargs)
+
+    def to_representation(self, instance):
+        if instance in ('', None):
+            return instance
+        try:
+            if not isinstance(instance, self.enum):
+                instance = self.enum(instance)  # Try to cast it
+            return instance.value
+        except ValueError:
+            raise ValueError('Invalid value [%r] of enum %s' % (
+                instance, self.enum.__name__))
+
+    def to_internal_value(self, data):
+        # Let data goes through ChoiceField.to_internal_value first
+        # So we don't need to handle int <-> str conversion (DRF behavior)
+        cleaned_data = super(EnumField, self).to_internal_value(data)
+        try:
+            return self.enum(cleaned_data)
+        except ValueError:
+            self.fail('invalid_choice', input=data)

--- a/enumfields/drf/serializers.py
+++ b/enumfields/drf/serializers.py
@@ -1,0 +1,16 @@
+from enumfields.fields import EnumFieldMixin
+from rest_framework.fields import ChoiceField
+
+from enumfields.drf.fields import EnumField as EnumSerializerField
+
+
+class EnumSupportSerializerMixin(object):
+    def build_standard_field(self, field_name, model_field):
+        field_class, field_kwargs = super(
+            EnumSupportSerializerMixin, self).build_standard_field(
+            field_name, model_field)
+        if field_class == ChoiceField and isinstance(
+                model_field, EnumFieldMixin):
+            field_class = EnumSerializerField
+            field_kwargs['enum'] = model_field.enum
+        return field_class, field_kwargs

--- a/enumfields/fields.py
+++ b/enumfields/fields.py
@@ -26,7 +26,11 @@ class CastOnAssignDescriptor(object):
     def __get__(self, obj, type=None):
         if obj is None:
             return self
-        return obj.__dict__[self.field.name]
+        if self.field.name in obj.__dict__:
+            return obj.__dict__[self.field.name]
+        else:
+            obj.refresh_from_db(fields=[self.field.name])
+            return getattr(obj, self.field.name)
 
     def __set__(self, obj, value):
         obj.__dict__[self.field.name] = self.field.to_python(value)

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
     tests_require=[
         'pytest-django',
         'Django',
+        'djangorestframework'
     ],
     cmdclass={'test': PyTest},
 )

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ class PyTest(TestCommand):
         errno = pytest.main(self.test_args)
         sys.exit(errno)
 
-install_requires = ['six']
+install_requires = ['six', 'qualname']
 try:
     import enum
 except ImportError:

--- a/tests/admin.py
+++ b/tests/admin.py
@@ -5,7 +5,7 @@ from django.contrib import admin
 
 from enumfields.admin import EnumFieldListFilter
 
-from .models import MyModel
+from .models import MyModel, RestrictedModel
 
 
 class MyModelAdmin(admin.ModelAdmin):
@@ -17,4 +17,9 @@ class MyModelAdmin(admin.ModelAdmin):
     ]
 
 
+class RestrictedModelAdmin(admin.ModelAdmin):
+    model = RestrictedModel
+
+
 admin.site.register(MyModel, MyModelAdmin)
+admin.site.register(RestrictedModel, RestrictedModelAdmin)

--- a/tests/enums.py
+++ b/tests/enums.py
@@ -49,3 +49,10 @@ class LabeledEnum(Enum):
         BAR = 'Bar'
         # this is intentional. see test_nonunique_label
         FOOBAR = 'Foo'
+
+
+class Zoo(object):
+    class Animal(Enum):
+        CAT = 0
+        DOG = 1
+        DINOSAUR = 2

--- a/tests/models.py
+++ b/tests/models.py
@@ -2,7 +2,7 @@ from django.db import models
 
 from enumfields import EnumField, EnumIntegerField
 
-from .enums import Color, IntegerEnum, LabeledEnum, Taste, ZeroEnum
+from .enums import Color, IntegerEnum, LabeledEnum, Taste, ZeroEnum, Zoo
 
 
 class MyModel(models.Model):
@@ -21,3 +21,8 @@ class MyModel(models.Model):
 
     zero2 = EnumIntegerField(ZeroEnum, default=ZeroEnum.ZERO)
     labeled_enum = EnumField(LabeledEnum, blank=True, null=True)
+
+
+class RestrictedModel(models.Model):
+    animal = EnumField(Zoo.Animal, default=Zoo.Animal.CAT, exclude=(Zoo.Animal.DINOSAUR,))
+    random_code = models.TextField(null=True, blank=True)

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -8,7 +8,7 @@ from django.forms import BaseForm
 
 from enumfields import EnumField
 
-from .enums import Color, IntegerEnum
+from .enums import Color, IntegerEnum, Zoo
 
 
 def test_choice_ordering():
@@ -67,4 +67,8 @@ def test_invalid_to_python_fails():
 
 
 def test_import_by_string():
-    assert EnumField("tests.test_enums.Color").enum == Color
+    assert EnumField("tests.enums.Color").enum == Color
+
+
+def test_import_by_sequence():
+    assert EnumField(("tests.enums", "Zoo.Animal")).enum == Zoo.Animal

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,0 +1,57 @@
+# -- encoding: UTF-8 --
+
+import uuid
+
+import pytest
+from django.db import connection
+from rest_framework import serializers
+
+from enumfields.drf.serializers import EnumSupportSerializerMixin
+
+from .models import MyModel
+from .enums import Color, IntegerEnum, LabeledEnum, Taste, ZeroEnum
+
+
+class MySerializer(EnumSupportSerializerMixin, serializers.ModelSerializer):
+    class Meta:
+        model = MyModel
+        fields = '__all__'
+
+
+def test_serialize():
+    inst = MyModel(color=Color.BLUE, taste=Taste.UMAMI, int_enum=IntegerEnum.B)
+    data = MySerializer(inst).data
+    assert data['color'] == Color.BLUE.value
+    assert data['taste'] == Taste.UMAMI.value
+    assert data['int_enum'] == IntegerEnum.B.value
+
+
+@pytest.mark.django_db
+def test_deserialize():
+    secret_uuid = str(uuid.uuid4())
+    data = {
+        'color': Color.BLUE.value,
+        'taste': Taste.UMAMI.value,
+        'int_enum': IntegerEnum.B.value,
+        'random_code': secret_uuid
+    }
+    serializer = MySerializer(data=data)
+    assert serializer.is_valid()
+
+    validated_data = serializer.validated_data
+    assert validated_data['color'] == Color.BLUE
+    assert validated_data['taste'] == Taste.UMAMI
+    assert validated_data['int_enum'] == IntegerEnum.B
+
+    inst = serializer.save()
+    assert inst.color == Color.BLUE
+    assert inst.taste == Taste.UMAMI
+    assert inst.int_enum == IntegerEnum.B
+
+    try:
+        inst = MyModel.objects.get(random_code=secret_uuid)
+    except DoesNotExist:
+        assert False, "Object wasn't created in the database"
+    assert inst.color == Color.BLUE
+    assert inst.taste == Taste.UMAMI
+    assert inst.int_enum == IntegerEnum.B

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -3,13 +3,12 @@
 import uuid
 
 import pytest
-from django.db import connection
 from rest_framework import serializers
 
 from enumfields.drf.serializers import EnumSupportSerializerMixin
 
 from .models import MyModel
-from .enums import Color, IntegerEnum, LabeledEnum, Taste, ZeroEnum
+from .enums import Color, IntegerEnum, Taste
 
 
 class MySerializer(EnumSupportSerializerMixin, serializers.ModelSerializer):


### PR DESCRIPTION
- Add Django-Rest-Framework support for EnumField  
- EnumField now can limit available choices in Admin page using include/exclude  
