### PR TITLE
Allow passing enum objects as data to form

### DIFF
--- a/enumfields/forms.py
+++ b/enumfields/forms.py
@@ -1,7 +1,11 @@
 # -- encoding: UTF-8 --
+from __future__ import absolute_import
+
 from django.forms import TypedChoiceField
 from django.forms.fields import TypedMultipleChoiceField
 from django.utils.encoding import force_text
+
+from .enums import Enum
 
 __all__ = ["EnumChoiceField", "EnumMultipleChoiceField"]
 
@@ -21,6 +25,11 @@ class EnumChoiceFieldMixin(object):
             if super(EnumChoiceFieldMixin, self).valid_value(value.value):
                 return True
         return super(EnumChoiceFieldMixin, self).valid_value(value)
+
+    def to_python(self, value):
+        if isinstance(value, Enum):
+            value = value.value
+        return super(EnumChoiceFieldMixin, self).to_python(value)
 
 
 class EnumChoiceField(EnumChoiceFieldMixin, TypedChoiceField):

--- a/tests/test_form_fields.py
+++ b/tests/test_form_fields.py
@@ -2,9 +2,9 @@
 import pytest
 import six
 from django.db.models import BLANK_CHOICE_DASH
-from django.forms.models import modelform_factory
+from django.forms.models import modelform_factory, model_to_dict
 
-from .enums import Color
+from .enums import Color, ZeroEnum
 from .models import MyModel
 
 
@@ -30,3 +30,13 @@ def test_choices():
     form = get_form()
     assert form.base_fields["zero2"].choices == [(0, 'Zero'), (1, 'One')]
     assert form.base_fields["int_enum"].choices == BLANK_CHOICE_DASH + [(0, 'foo'), (1, 'B')]
+
+
+def test_validation():
+    form = get_form(data={"color": Color.GREEN, "zero2": ZeroEnum.ZERO})
+    assert form.is_valid(), form.errors
+
+    instance = MyModel(color=Color.RED, zero2=ZeroEnum.ZERO)
+    data = model_to_dict(instance, fields=("color", "zero2", "int_enum"))
+    form = get_form(data=data)
+    assert form.is_valid(), form.errors


### PR DESCRIPTION
## Changes

This PR makes a minor tweak to the formfields to make testing `ModelForms` easier. 

## Why?
A common pattern in testing Django `ModelForm` behavior is to create a model instance, then instantiate a form with modified data for that instance, then call `form.save()`, and add assertions about what happened.

AFAICT, Django doesn't provide an officially supported way of doing this, but a common method of building the data dictionary is either:
1. Build the data dictionary by hand, or
2. Call the `model_to_dict` method and use that.

In the former case, you need to define the data dictionary like this:
```
data = {
		"my_field": MyEnum.THING.value,
		...
}
```
...which is annoying to remember.  In the latter case, you need to do a transform
to the data, finding all enums and accessing their `.value` attribute.

## Testing

I added a failing test for the new behavior, and verified it passes on the HEAD of this branch.