### PR TITLE
Django REST Framework support

### DIFF
--- a/enumfields/drf/__init__.py
+++ b/enumfields/drf/__init__.py
@@ -1,0 +1,2 @@
+from .fields import EnumField
+from .serializers import EnumSupportSerializerMixin

--- a/enumfields/drf/fields.py
+++ b/enumfields/drf/fields.py
@@ -1,0 +1,29 @@
+from rest_framework.fields import ChoiceField
+
+
+class EnumField(ChoiceField):
+    def __init__(self, enum, **kwargs):
+        self.enum = enum
+        kwargs['choices'] = tuple((e.value, getattr(e, 'label', e.name)) for e in self.enum)
+        super(EnumField, self).__init__(**kwargs)
+
+    def to_representation(self, instance):
+        if instance in ('', u'', None):
+            return instance
+        try:
+            if not isinstance(instance, self.enum):
+                instance = self.enum(instance)  # Try to cast it
+            return instance.value
+        except ValueError:
+            raise ValueError('Invalid value [%r] of enum %s' % (instance, self.enum.__name__))
+
+    def to_internal_value(self, data):
+        if isinstance(data, self.enum):
+            return data
+        # Let data goes through ChoiceField.to_internal_value first
+        # So we don't need to handle int <-> str conversion (DRF behavior)
+        cleaned_data = super(EnumField, self).to_internal_value(data)
+        try:
+            return self.enum(cleaned_data)
+        except ValueError:
+            self.fail('invalid_choice', input=data)

--- a/enumfields/drf/fields.py
+++ b/enumfields/drf/fields.py
@@ -1,9 +1,20 @@
+from django.utils import six
+from django.utils.encoding import force_text
 from rest_framework.fields import ChoiceField
 
 
 class EnumField(ChoiceField):
-    def __init__(self, enum, **kwargs):
+    def __init__(self, enum, lenient=False, ints_as_names=False, **kwargs):
+        """
+        :param enum: The enumeration class. 
+        :param lenient: Whether to allow lenient parsing (case-insensitive, by value or name)
+        :type lenient: bool
+        :param ints_as_names: Whether to serialize integer-valued enums by their name, not the integer value
+        :type ints_as_names: bool
+        """
         self.enum = enum
+        self.lenient = lenient
+        self.ints_as_names = ints_as_names
         kwargs['choices'] = tuple((e.value, getattr(e, 'label', e.name)) for e in self.enum)
         super(EnumField, self).__init__(**kwargs)
 
@@ -13,6 +24,9 @@ class EnumField(ChoiceField):
         try:
             if not isinstance(instance, self.enum):
                 instance = self.enum(instance)  # Try to cast it
+            if self.ints_as_names and isinstance(instance.value, six.integer_types):
+                # If the enum value is an int, assume the name is more representative
+                return instance.name.lower()
             return instance.value
         except ValueError:
             raise ValueError('Invalid value [%r] of enum %s' % (instance, self.enum.__name__))
@@ -20,10 +34,24 @@ class EnumField(ChoiceField):
     def to_internal_value(self, data):
         if isinstance(data, self.enum):
             return data
-        # Let data goes through ChoiceField.to_internal_value first
-        # So we don't need to handle int <-> str conversion (DRF behavior)
-        cleaned_data = super(EnumField, self).to_internal_value(data)
         try:
-            return self.enum(cleaned_data)
-        except ValueError:
-            self.fail('invalid_choice', input=data)
+            # Convert the value using the same mechanism DRF uses
+            converted_value = self.choice_strings_to_values[six.text_type(data)]
+            return self.enum(converted_value)
+        except (ValueError, KeyError):
+            pass
+
+        if self.lenient:
+            # Normal logic:
+            for choice in self.enum:
+                if choice.name == data or choice.value == data:
+                    return choice
+
+            # Case-insensitive logic:
+            l_data = force_text(data).lower()
+            for choice in self.enum:
+                if choice.name.lower() == l_data or force_text(choice.value).lower() == l_data:
+                    return choice
+
+        # Fallback (will likely just raise):
+        return super(EnumField, self).to_internal_value(data)

--- a/enumfields/drf/serializers.py
+++ b/enumfields/drf/serializers.py
@@ -1,9 +1,12 @@
+from rest_framework.fields import ChoiceField
+
 from enumfields.drf.fields import EnumField as EnumSerializerField
 from enumfields.fields import EnumFieldMixin
-from rest_framework.fields import ChoiceField
 
 
 class EnumSupportSerializerMixin(object):
+    enumfield_options = {}
+
     def build_standard_field(self, field_name, model_field):
         field_class, field_kwargs = (
             super(EnumSupportSerializerMixin, self).build_standard_field(field_name, model_field)
@@ -11,4 +14,5 @@ class EnumSupportSerializerMixin(object):
         if field_class == ChoiceField and isinstance(model_field, EnumFieldMixin):
             field_class = EnumSerializerField
             field_kwargs['enum'] = model_field.enum
+            field_kwargs.update(self.enumfield_options)
         return field_class, field_kwargs

--- a/enumfields/drf/serializers.py
+++ b/enumfields/drf/serializers.py
@@ -1,0 +1,14 @@
+from enumfields.drf.fields import EnumField as EnumSerializerField
+from enumfields.fields import EnumFieldMixin
+from rest_framework.fields import ChoiceField
+
+
+class EnumSupportSerializerMixin(object):
+    def build_standard_field(self, field_name, model_field):
+        field_class, field_kwargs = (
+            super(EnumSupportSerializerMixin, self).build_standard_field(field_name, model_field)
+        )
+        if field_class == ChoiceField and isinstance(model_field, EnumFieldMixin):
+            field_class = EnumSerializerField
+            field_kwargs['enum'] = model_field.enum
+        return field_class, field_kwargs

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
     tests_require=[
         'pytest-django',
         'Django',
+        'djangorestframework'
     ],
     extras_require={
         ":python_version<'3.4'": ['enum34'],

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,0 +1,56 @@
+# -- encoding: UTF-8 --
+
+import uuid
+
+import pytest
+from rest_framework import serializers
+
+from enumfields.drf.serializers import EnumSupportSerializerMixin
+
+from .models import MyModel
+from .enums import Color, IntegerEnum, Taste
+
+
+class MySerializer(EnumSupportSerializerMixin, serializers.ModelSerializer):
+    class Meta:
+        model = MyModel
+        fields = '__all__'
+
+
+def test_serialize():
+    inst = MyModel(color=Color.BLUE, taste=Taste.UMAMI, int_enum=IntegerEnum.B)
+    data = MySerializer(inst).data
+    assert data['color'] == Color.BLUE.value
+    assert data['taste'] == Taste.UMAMI.value
+    assert data['int_enum'] == IntegerEnum.B.value
+
+
+@pytest.mark.django_db
+def test_deserialize():
+    secret_uuid = str(uuid.uuid4())
+    data = {
+        'color': Color.BLUE.value,
+        'taste': Taste.UMAMI.value,
+        'int_enum': IntegerEnum.B.value,
+        'random_code': secret_uuid
+    }
+    serializer = MySerializer(data=data)
+    assert serializer.is_valid()
+
+    validated_data = serializer.validated_data
+    assert validated_data['color'] == Color.BLUE
+    assert validated_data['taste'] == Taste.UMAMI
+    assert validated_data['int_enum'] == IntegerEnum.B
+
+    inst = serializer.save()
+    assert inst.color == Color.BLUE
+    assert inst.taste == Taste.UMAMI
+    assert inst.int_enum == IntegerEnum.B
+
+    try:
+        inst = MyModel.objects.get(random_code=secret_uuid)
+    except DoesNotExist:
+        assert False, "Object wasn't created in the database"
+    assert inst.color == Color.BLUE
+    assert inst.taste == Taste.UMAMI
+    assert inst.int_enum == IntegerEnum.B


### PR DESCRIPTION
This builds on @NovaDev94 's excellent work in PR #68.

* The DRF features were extracted from e7cbffca7bc

In addition, there are some new features I've needed in personal work using DRF and enums:

* A new `lenient` parsing mode for enums was added; it allows parsing enums case-insensitively, and by name _or_ value. This is opt-in.
* A mode that serializes integer-valued enums by their name was added. This is opt-in and is sort of the other half to the `lenient` mode.