### PR TITLE
Replace deprecated API call

### DIFF
--- a/enumfields/fields.py
+++ b/enumfields/fields.py
@@ -78,7 +78,7 @@ class EnumFieldMixin(object):
         Since most of the enum values are strings or integers we WILL NOT convert it to string
         to enable integers to be serialized natively.
         """
-        value = self._get_val_from_obj(obj)
+        value = self.value_from_object(obj)
         return value.value if value else None
 
     def get_default(self):


### PR DESCRIPTION
`_get_val_from_obj` is equivalent to `value_from_object` but has been deprecated, and is removed in Django 2.0, as per https://code.djangoproject.com/ticket/24716