### PR TITLE
Replaces call to _get_val_from_obj with value_from_object.

### DIFF
--- a/enumfields/fields.py
+++ b/enumfields/fields.py
@@ -78,7 +78,7 @@ class EnumFieldMixin(object):
         Since most of the enum values are strings or integers we WILL NOT convert it to string
         to enable integers to be serialized natively.
         """
-        value = self._get_val_from_obj(obj)
+        value = self.value_from_object(obj)
         return value.value if value else None
 
     def get_default(self):


### PR DESCRIPTION
This makes enumfield compatible with Django 2.0 where the deprecated
function _get_val_from_obj has been removed. The value_from_object
function performs the same operation and is supported in both Django 2.0
and previous versions.