### PR TITLE
Django 2.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,30 @@
 sudo: false
 language: python
-python:
-  - '2.7'
-  - '3.4'
-  - '3.5'
-  - '3.6'
+matrix:
+  include:
+    - python: '2.7'
+      env: TOXENV=py27-django18
+    - python: '3.4'
+      env: TOXENV=py34-django18
+    - python: '3.5'
+      env: TOXENV=py35-django18
+
+    - python: '2.7'
+      env: TOXENV=py27-django110
+    - python: '3.4'
+      env: TOXENV=py34-django110
+    - python: '3.5'
+      env: TOXENV=py35-django110
+
+    - python: '2.7'
+      env: TOXENV=py27-django111
+    - python: '3.4'
+      env: TOXENV=py34-django111
+    - python: '3.5'
+      env: TOXENV=py35-django111
+    - python: '3.6'
+      env: TOXENV=py36-django111
 install:
   - pip install -U pip wheel setuptools
-  - pip install tox tox-travis
+  - pip install tox
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,14 @@ matrix:
       env: TOXENV=py35-django111
     - python: '3.6'
       env: TOXENV=py36-django111
+
+    - python: '3.4'
+      env: TOXENV=py34-django20
+    - python: '3.5'
+      env: TOXENV=py35-django20
+    - python: '3.6'
+      env: TOXENV=py36-django20
+
 install:
   - pip install -U pip wheel setuptools
   - pip install tox

--- a/enumfields/fields.py
+++ b/enumfields/fields.py
@@ -1,5 +1,6 @@
 from enum import Enum
 
+import django
 from django.utils import six
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -78,7 +79,10 @@ class EnumFieldMixin(object):
         Since most of the enum values are strings or integers we WILL NOT convert it to string
         to enable integers to be serialized natively.
         """
-        value = self._get_val_from_obj(obj)
+        if django.VERSION >= (2, 0):
+            value = self.value_from_object(obj)
+        else:
+            value = self._get_val_from_obj(obj)
         return value.value if value else None
 
     def get_default(self):

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,9 @@ setup(
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',
+        'Framework :: Django :: 1.8',
+        'Framework :: Django :: 1.10',
+        'Framework :: Django :: 1.11',
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',
         'Programming Language :: Python',

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         'Framework :: Django :: 1.8',
         'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.0',
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',
         'Programming Language :: Python',

--- a/tests/test_form_fields.py
+++ b/tests/test_form_fields.py
@@ -1,4 +1,5 @@
 # -- encoding: UTF-8 --
+import django
 import pytest
 from django.utils import six
 from django.db.models import BLANK_CHOICE_DASH
@@ -17,13 +18,19 @@ def get_form(**kwargs):
 @pytest.mark.django_db
 def test_unbound_form_with_instance():
     form = get_form()
-    assert 'value="r" selected="selected"' in six.text_type(form["color"])
+    if django.VERSION >= (1, 11):
+        assert 'value="r" selected' in six.text_type(form["color"])
+    else:
+        assert 'value="r" selected="selected"' in six.text_type(form["color"])
 
 
 @pytest.mark.django_db
 def test_bound_form_with_instance():
     form = get_form(data={"color": "g"})
-    assert 'value="g" selected="selected"' in six.text_type(form["color"])
+    if django.VERSION >= (1, 11):
+        assert 'value="g" selected' in six.text_type(form["color"])
+    else:
+        assert 'value="g" selected="selected"' in six.text_type(form["color"])
 
 
 def test_choices():

--- a/tox.ini
+++ b/tox.ini
@@ -2,12 +2,6 @@
 envlist =
     {py27,py34,py35,py36}-{django18,django110,django111}
 
-[tox:travis]
-2.7 = py27
-3.4 = py34
-3.5 = py35
-3.6 = py36
-
 [testenv]
 setenv = PYTHONPATH = {toxinidir}
 commands = python setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    {py27,py34,py35,py36}-{django18,django19,django110}
+    {py27,py34,py35,py36}-{django18,django19,django110,django111}
 
 [tox:travis]
 2.7 = py27
@@ -15,3 +15,4 @@ deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<2

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    {py27,py34,py35,py36}-{django18,django19,django110,django111}
+    {py27,py34,py35,py36}-{django18,django110,django111}
 
 [tox:travis]
 2.7 = py27
@@ -13,6 +13,5 @@ setenv = PYTHONPATH = {toxinidir}
 commands = python setup.py test
 deps =
     django18: Django>=1.8,<1.9
-    django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<2

--- a/tox.ini
+++ b/tox.ini
@@ -13,5 +13,6 @@ setenv = PYTHONPATH = {toxinidir}
 commands = python setup.py test
 deps =
     django18: Django>=1.8,<1.9
+    django18: djangorestframework<3.7
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<2

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    {py27,py34,py35,py36}-{django18,django110,django111}
+    py{27,34,35,36}-django{18,110,111}, py{34,35,36}-django{20}
 
 [testenv]
 setenv = PYTHONPATH = {toxinidir}
@@ -10,3 +10,4 @@ deps =
     django18: djangorestframework<3.7
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<2
+    django20: Django>=2.0,<2.1


### PR DESCRIPTION
Add Django 2.0 to test matrix. Use `value_for_object` instead with Django 2.0 instead of deprecated `_get_val_for_obj`.

Based on top of the test matrix changes made by @EvaSDK in PR #79.

Supersedes PR #81.