### PR TITLE
fix tests for django 2.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ exclude = migrations
 max-line-length = 120
 max-complexity = 10
 
-[pytest]
+[tool:pytest]
 DJANGO_SETTINGS_MODULE = tests.settings
 norecursedirs = .git .tox .eggs .cache htmlcov venv*
 doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ALLOW_UNICODE

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,3 +1,5 @@
+import django
+
 SECRET_KEY = 'SEKRIT'
 
 INSTALLED_APPS = (
@@ -17,11 +19,18 @@ DATABASES = {
     },
 }
 
-MIDDLEWARE_CLASSES = (
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-)
+if django.VERSION[0] < 2:
+    MIDDLEWARE_CLASSES = (
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
+    )
+else:
+    MIDDLEWARE = (
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
+    )
 
 # Speed up tests by using a deliberately weak hasher instead of pbkdf/bcrypt:
 PASSWORD_HASHERS = ['django.contrib.auth.hashers.MD5PasswordHasher']

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,14 +1,20 @@
 # -*- coding: utf-8 -*-
 from django.conf import settings
 from django.conf.urls import include, url
+import django
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 
 admin.autodiscover()
 
-urlpatterns = [
-    url(r'^admin/', include(admin.site.urls)),
-]
+if django.VERSION[0] < 2:
+    urlpatterns = [
+        url(r'^admin/', include(admin.site.urls)),
+    ]
+else:
+    urlpatterns = [
+        url(r'^admin/', admin.site.urls),
+    ]
 
 if settings.DEBUG:
     urlpatterns = staticfiles_urlpatterns() + urlpatterns


### PR DESCRIPTION
Fixed 2 needed changes for django 2.0 : 
* In settings.py - `MIDDLEWARE_CLASSES` -> `MIDDLEWARE`
* In urls.py - removing the call to `include()`

Also fixed the warning of setup.cfg.