### PR TITLE
Removed explicit context argument

### DIFF
--- a/enumfields/fields.py
+++ b/enumfields/fields.py
@@ -69,7 +69,7 @@ class EnumFieldMixin(object):
             return value.value
         return self.enum(value).value
 
-    def from_db_value(self, value, expression, connection, context):
+    def from_db_value(self, value, expression, connection, *args):
         return self.to_python(value)
 
     def value_to_string(self, obj):


### PR DESCRIPTION
Silences a deprecation warning from Django 2.0.