### PR TITLE
Fix EnumSupportSerializerMixin for not editable model fields

### DIFF
--- a/enumfields/drf/serializers.py
+++ b/enumfields/drf/serializers.py
@@ -1,4 +1,4 @@
-from rest_framework.fields import ChoiceField
+from rest_framework.fields import ChoiceField, CharField
 
 from enumfields.drf.fields import EnumField as EnumSerializerField
 from enumfields.fields import EnumFieldMixin
@@ -11,7 +11,7 @@ class EnumSupportSerializerMixin(object):
         field_class, field_kwargs = (
             super(EnumSupportSerializerMixin, self).build_standard_field(field_name, model_field)
         )
-        if field_class == ChoiceField and isinstance(model_field, EnumFieldMixin):
+        if field_class in (ChoiceField, CharField) and isinstance(model_field, EnumFieldMixin):
             field_class = EnumSerializerField
             field_kwargs['enum'] = model_field.enum
             field_kwargs.update(self.enumfield_options)

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,8 @@ setup(
     tests_require=[
         'pytest-django',
         'Django',
-        'djangorestframework'
+        'djangorestframework',
+        'pytz',
     ],
     extras_require={
         ":python_version<'3.4'": ['enum34'],

--- a/tests/models.py
+++ b/tests/models.py
@@ -7,7 +7,10 @@ from .enums import Color, IntegerEnum, LabeledEnum, Taste, ZeroEnum
 
 class MyModel(models.Model):
     color = EnumField(Color, max_length=1)
+    color_not_editable = EnumField(Color, max_length=1, editable=False, null=True)
+
     taste = EnumField(Taste, default=Taste.SWEET)
+    taste_not_editable = EnumField(Taste, default=Taste.SWEET, editable=False)
     taste_null_default = EnumField(Taste, null=True, blank=True, default=None)
     taste_int = EnumIntegerField(Taste, default=Taste.SWEET)
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -26,14 +26,23 @@ class LenientIntNameSerializer(MySerializer):
 
 @pytest.mark.parametrize('int_names', (False, True))
 def test_serialize(int_names):
-    inst = MyModel(color=Color.BLUE, taste=Taste.UMAMI, int_enum=IntegerEnum.B)
+    inst = MyModel(
+        color=Color.BLUE,
+        color_not_editable=Color.BLUE,
+        taste=Taste.UMAMI,
+        taste_not_editable=Taste.UMAMI,
+        int_enum=IntegerEnum.B
+    )
     data = (LenientIntNameSerializer if int_names else MySerializer)(inst).data
     assert data['color'] == Color.BLUE.value
+    assert data['color_not_editable'] == Color.BLUE.value
     if int_names:
         assert data['taste'] == 'umami'
+        assert data['taste_not_editable'] == 'umami'
         assert data['int_enum'] == 'b'
     else:
         assert data['taste'] == Taste.UMAMI.value
+        assert data['taste_not_editable'] == Taste.UMAMI.value
         assert data['int_enum'] == IntegerEnum.B.value
 
 


### PR DESCRIPTION
Hi, I faced with the issue: EnumSupportSerializerMixin doesn't work with not editable fields.

And there is a simple solution