### PR TITLE
Add support for Python 3.7 and Django 2.1-2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: python
+dist: xenial
 matrix:
   include:
     - python: '2.7'
@@ -24,6 +25,8 @@ matrix:
       env: TOXENV=py35-django111
     - python: '3.6'
       env: TOXENV=py36-django111
+    - python: '3.7'
+      env: TOXENV=py37-django111
 
     - python: '3.4'
       env: TOXENV=py34-django20
@@ -31,6 +34,15 @@ matrix:
       env: TOXENV=py35-django20
     - python: '3.6'
       env: TOXENV=py36-django20
+    - python: '3.7'
+      env: TOXENV=py37-django20
+
+    - python: '3.5'
+      env: TOXENV=py35-django21
+    - python: '3.6'
+      env: TOXENV=py36-django21
+    - python: '3.7'
+      env: TOXENV=py37-django21
 
 install:
   - pip install -U pip wheel setuptools

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,13 @@ matrix:
     - python: '3.7'
       env: TOXENV=py37-django21
 
+    - python: '3.5'
+      env: TOXENV=py35-django22
+    - python: '3.6'
+      env: TOXENV=py36-django22
+    - python: '3.7'
+      env: TOXENV=py37-django22
+
 install:
   - pip install -U pip wheel setuptools
   - pip install tox

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.1',
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
@@ -54,6 +55,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Internet :: WWW/HTTP',
     ],
     tests_require=[

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',
+        'Framework :: Django :: 2.2',
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',
         'Programming Language :: Python',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{27,34,35,36}-django{18,110,111}, py{34,35,36,37}-django{20}, py{35,36,37}-django{21}
+    py{27,34,35,36}-django{18,110,111}, py{34,35,36,37}-django{20}, py{35,36,37}-django{21,22}
 
 [testenv]
 setenv = PYTHONPATH = {toxinidir}
@@ -12,3 +12,4 @@ deps =
     django111: Django>=1.11,<2
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
+    django22: Django>=2.2,<2.3

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{27,34,35,36}-django{18,110,111}, py{34,35,36}-django{20}
+    py{27,34,35,36}-django{18,110,111}, py{34,35,36,37}-django{20}, py{35,36,37}-django{21}
 
 [testenv]
 setenv = PYTHONPATH = {toxinidir}
@@ -11,3 +11,4 @@ deps =
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<2
     django20: Django>=2.0,<2.1
+    django21: Django>=2.1,<2.2


### PR DESCRIPTION
Supported Python versions are: https://docs.djangoproject.com/en/2.1/faq/install/#what-python-version-can-i-use-with-django

`dist: xenial` is required for Python 3.7+.