### PR TITLE
Add PyPI badges to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,11 @@ This package lets you use real Python (PEP435_-style) enums with Django.
 .. image:: https://travis-ci.org/hzdg/django-enumfields.svg?branch=master
     :target: https://travis-ci.org/hzdg/django-enumfields
 
+.. image:: https://img.shields.io/pypi/v/django-enumfields.svg
+    :target: https://pypi.python.org/pypi/django-enumfields
+
+.. image:: https://img.shields.io/pypi/pyversions/django-enumfields.svg
+    :target: https://pypi.python.org/pypi/django-enumfields/
 
 Installation
 ------------


### PR DESCRIPTION
Build failure is unrelated, and can be fixed in master with this commit: https://github.com/hzdg/django-enumfields/pull/90/commits/3c44881bd5b49f07e364ea799c978b19dc3180e8