### PR TITLE
Fix minor typos in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,4 +95,4 @@ EnumFieldListFilter
     from enumfields.admin import EnumFieldListFilter
 
     class MyModelAdmin(admin.ModelAdmin):
-      list_filter = [('color', EnumFieldListFilter)]
+        list_filter = [('color', EnumFieldListFilter)]

--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ Enum
 ````
 
 Normally, you just use normal PEP435_-style enums, however, django-enumfields
-also encludes its own version of Enum with a few extra bells and whistles.
+also includes its own version of Enum with a few extra bells and whistles.
 Namely, the smart definition of labels which are used, for example, in admin
 dropdowns. By default, it will create labels by title-casing your constant
 names. You can provide custom labels with a nested "Labels" class.


### PR DESCRIPTION
Build failure is unrelated, and can be fixed in master with this commit: https://github.com/hzdg/django-enumfields/pull/90/commits/3c44881bd5b49f07e364ea799c978b19dc3180e8