### PR TITLE
Changed EnumField max_length to default to the longest string value in the Enum

### DIFF
--- a/enumfields/fields.py
+++ b/enumfields/fields.py
@@ -129,7 +129,8 @@ class EnumFieldMixin(object):
 
 class EnumField(EnumFieldMixin, models.CharField):
     def __init__(self, enum, **kwargs):
-        kwargs.setdefault("max_length", 10)
+        max_length = max([len(e.value) for e in enum])
+        kwargs.setdefault("max_length", max_length)
         super(EnumField, self).__init__(enum, **kwargs)
         self.validators = []
 


### PR DESCRIPTION
While using `django-enumfields`, I came across the restriction of needing to specify the `max_length` of the `EnumField` every time I used the field. As the default `max_length` was restricted to 10 chars, it to be limiting, and therefore created this PR.

Unlike a `CharField` in Django, where the size of the actual content is unknown, because the Enum is a predefined value, the default value for `max_length` could be dynamic according to the length of the longest enum value.

Note: When changing the enum values and running `python manage.py makemigrations`, the field will be altered to the new max length, if one is not explicitly specified.