### PR TITLE
Warn when some values of an enum won't fit in the backing database field

### DIFF
--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,0 +1,9 @@
+from enumfields import EnumField
+from django.db import models
+from tests.enums import LabeledEnum
+
+
+def test_shortness_check():
+    class TestModel(models.Model):
+        f = EnumField(LabeledEnum, max_length=3, blank=True, null=True)
+    assert any([m.id == 'enumfields.max_length_fit' for m in TestModel.check()])


### PR DESCRIPTION
This PR adds a system check to add an early warning when the backing `CharField` for an `EnumField` isn't long enough to fit all of the enum's values.

I prefer this implementation to #91 and #99 because:

* No additional parameter is added (like in #91)
* Using a system check instead of raising an exception should also be safe wrt. migrations (#91)
* Adding values to the enum won't cause a mystery migration without user intervention (#99)

Closes #91 
Closes #99 