### PR TITLE
Support Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,14 +31,14 @@ matrix:
     - python: '3.7'
       env: TOXENV=py37-django22
     - python: '3.8'
-      env: TOXENV=py37-django22
+      env: TOXENV=py38-django22
 
     - python: '3.6'
       env: TOXENV=py36-django30
     - python: '3.7'
       env: TOXENV=py37-django30
     - python: '3.8'
-      env: TOXENV=py37-django22
+      env: TOXENV=py38-django30
 
 install:
   - pip install -U pip wheel setuptools

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,15 @@ matrix:
       env: TOXENV=py36-django22
     - python: '3.7'
       env: TOXENV=py37-django22
+    - python: '3.8'
+      env: TOXENV=py37-django22
 
     - python: '3.6'
       env: TOXENV=py36-django30
     - python: '3.7'
       env: TOXENV=py37-django30
+    - python: '3.8'
+      env: TOXENV=py37-django22
 
 install:
   - pip install -U pip wheel setuptools

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Internet :: WWW/HTTP',
     ],
 )


### PR DESCRIPTION
Supported Django version for 3.8 pulled from: https://docs.djangoproject.com/en/3.0/faq/install/#what-python-version-can-i-use-with-django