### PR TITLE
Fix EnumSupportSerializerMixin for non-editable fields

### DIFF
--- a/enumfields/drf/serializers.py
+++ b/enumfields/drf/serializers.py
@@ -1,16 +1,17 @@
 from enumfields.drf.fields import EnumField as EnumSerializerField
 from enumfields.fields import EnumFieldMixin
-from rest_framework.fields import ChoiceField
+from rest_framework.fields import CharField, ChoiceField, IntegerField
 
 
 class EnumSupportSerializerMixin:
     enumfield_options = {}
+    enumfield_classes_to_replace = (ChoiceField, CharField, IntegerField)
 
     def build_standard_field(self, field_name, model_field):
         field_class, field_kwargs = (
             super().build_standard_field(field_name, model_field)
         )
-        if field_class == ChoiceField and isinstance(model_field, EnumFieldMixin):
+        if isinstance(model_field, EnumFieldMixin) and field_class in self.enumfield_classes_to_replace:
             field_class = EnumSerializerField
             field_kwargs['enum'] = model_field.enum
             field_kwargs.update(self.enumfield_options)

--- a/tests/models.py
+++ b/tests/models.py
@@ -7,7 +7,10 @@ from .enums import Color, IntegerEnum, LabeledEnum, Taste, ZeroEnum
 
 class MyModel(models.Model):
     color = EnumField(Color, max_length=1)
+    color_not_editable = EnumField(Color, max_length=1, editable=False, null=True)
+
     taste = EnumField(Taste, default=Taste.SWEET)
+    taste_not_editable = EnumField(Taste, default=Taste.SWEET, editable=False)
     taste_null_default = EnumField(Taste, null=True, blank=True, default=None)
     taste_int = EnumIntegerField(Taste, default=Taste.SWEET)
 
@@ -18,6 +21,7 @@ class MyModel(models.Model):
 
     zero_field = EnumIntegerField(ZeroEnum, null=True, default=None, blank=True)
     int_enum = EnumIntegerField(IntegerEnum, null=True, default=None, blank=True)
+    int_enum_not_editable = EnumIntegerField(IntegerEnum, default=IntegerEnum.A, editable=False)
 
     zero2 = EnumIntegerField(ZeroEnum, default=ZeroEnum.ZERO)
     labeled_enum = EnumField(LabeledEnum, blank=True, null=True)

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -23,15 +23,23 @@ class LenientIntNameSerializer(MySerializer):
 
 @pytest.mark.parametrize('int_names', (False, True))
 def test_serialize(int_names):
-    inst = MyModel(color=Color.BLUE, taste=Taste.UMAMI, int_enum=IntegerEnum.B)
+    inst = MyModel(
+        color=Color.BLUE,
+        color_not_editable=Color.BLUE,
+        taste=Taste.UMAMI,
+        taste_not_editable=Taste.UMAMI,
+        int_enum=IntegerEnum.B,
+        int_enum_not_editable=IntegerEnum.B
+    )
     data = (LenientIntNameSerializer if int_names else MySerializer)(inst).data
-    assert data['color'] == Color.BLUE.value
+    assert data['color'] == data['color_not_editable'] == Color.BLUE.value
+    assert Color.BLUE.value
     if int_names:
-        assert data['taste'] == 'umami'
-        assert data['int_enum'] == 'b'
+        assert data['taste'] == data['taste_not_editable'] == 'umami'
+        assert data['int_enum'] == data['int_enum_not_editable'] == 'b'
     else:
-        assert data['taste'] == Taste.UMAMI.value
-        assert data['int_enum'] == IntegerEnum.B.value
+        assert data['taste'] == data['taste_not_editable'] == Taste.UMAMI.value
+        assert data['int_enum'] == data['int_enum_not_editable'] == IntegerEnum.B.value
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
While DRF would regularly emit a ChoiceField for an enum field, it emits a read-only CharField or IntegerField for a non-editable field instead.

Based on @ADR-007's solution in #90, but adds support for integer enums too.

Closes #90 (rebased duplicate)