### PR TITLE
Add license trove classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     packages=find_packages(exclude=['tests*']),
     zip_safe=False,
     classifiers=[
+        'License :: OSI Approved :: MIT License',
         'Environment :: Web Environment',
         'Framework :: Django',
         'Framework :: Django :: 1.11',


### PR DESCRIPTION
This is the preferred way to represent license information, and is used by `pip-licenses` summary report to include `django-enumfields` with other MIT licensed packages.