### PR TITLE
Drop support for EOL Django versions < 2 and increase test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,29 +3,6 @@ language: python
 dist: xenial
 matrix:
   include:
-    - python: '3.5'
-      env: TOXENV=py35-django111
-    - python: '3.6'
-      env: TOXENV=py36-django111
-    - python: '3.7'
-      env: TOXENV=py37-django111
-
-    - python: '3.5'
-      env: TOXENV=py35-django20
-    - python: '3.6'
-      env: TOXENV=py36-django20
-    - python: '3.7'
-      env: TOXENV=py37-django20
-
-    - python: '3.5'
-      env: TOXENV=py35-django21
-    - python: '3.6'
-      env: TOXENV=py36-django21
-    - python: '3.7'
-      env: TOXENV=py37-django21
-
-    - python: '3.5'
-      env: TOXENV=py35-django22
     - python: '3.6'
       env: TOXENV=py36-django22
     - python: '3.7'
@@ -39,6 +16,13 @@ matrix:
       env: TOXENV=py37-django30
     - python: '3.8'
       env: TOXENV=py38-django30
+
+    - python: '3.6'
+      env: TOXENV=py36-django31
+    - python: '3.7'
+      env: TOXENV=py37-django31
+    - python: '3.8'
+      env: TOXENV=py38-django31
 
 install:
   - pip install -U pip wheel setuptools

--- a/enumfields/drf/fields.py
+++ b/enumfields/drf/fields.py
@@ -6,7 +6,7 @@ from rest_framework.fields import ChoiceField
 class EnumField(ChoiceField):
     def __init__(self, enum, lenient=False, ints_as_names=False, **kwargs):
         """
-        :param enum: The enumeration class. 
+        :param enum: The enumeration class.
         :param lenient: Whether to allow lenient parsing (case-insensitive, by value or name)
         :type lenient: bool
         :param ints_as_names: Whether to serialize integer-valued enums by their name, not the integer value

--- a/enumfields/drf/fields.py
+++ b/enumfields/drf/fields.py
@@ -19,17 +19,11 @@ class EnumField(ChoiceField):
         super().__init__(**kwargs)
 
     def to_representation(self, instance):
-        if instance in ('', None):
-            return instance
-        try:
-            if not isinstance(instance, self.enum):
-                instance = self.enum(instance)  # Try to cast it
-            if self.ints_as_names and isinstance(instance.value, int):
-                # If the enum value is an int, assume the name is more representative
-                return instance.name.lower()
-            return instance.value
-        except ValueError:
-            raise ValueError('Invalid value [{!r}] of enum {}'.format(instance, self.enum.__name__))
+        assert isinstance(instance, self.enum), instance
+        if self.ints_as_names and isinstance(instance.value, int):
+            # If the enum value is an int, assume the name is more representative
+            return instance.name.lower()
+        return instance.value
 
     def to_internal_value(self, data):
         if isinstance(data, self.enum):

--- a/enumfields/fields.py
+++ b/enumfields/fields.py
@@ -1,6 +1,5 @@
 from enum import Enum
 
-import django
 from django.core import checks
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -79,10 +78,7 @@ class EnumFieldMixin:
         Since most of the enum values are strings or integers we WILL NOT convert it to string
         to enable integers to be serialized natively.
         """
-        if django.VERSION >= (2, 0):
-            value = self.value_from_object(obj)
-        else:
-            value = self._get_val_from_obj(obj)
+        value = self.value_from_object(obj)
         return value.value if value else None
 
     def get_default(self):

--- a/enumfields/forms.py
+++ b/enumfields/forms.py
@@ -17,12 +17,6 @@ class EnumChoiceFieldMixin:
             value = value.value
         return force_str(value)
 
-    def valid_value(self, value):
-        if hasattr(value, "value"):  # Try validation using the enum value first.
-            if super().valid_value(value.value):
-                return True
-        return super().valid_value(value)
-
     def to_python(self, value):
         if isinstance(value, Enum):
             value = value.value

--- a/setup.py
+++ b/setup.py
@@ -28,11 +28,9 @@ setup(
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 1.11',
-        'Framework :: Django :: 2.0',
-        'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',
+        'Framework :: Django :: 3.1',
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',
         'Programming Language :: Python',

--- a/tests/models.py
+++ b/tests/models.py
@@ -19,11 +19,10 @@ class MyModel(models.Model):
 
     random_code = models.TextField(null=True, blank=True)
 
-    zero_field = EnumIntegerField(ZeroEnum, null=True, default=None, blank=True)
+    zero = EnumIntegerField(ZeroEnum, default=ZeroEnum.ZERO)
+    zero2 = EnumIntegerField(ZeroEnum, default=0, blank=True)
+
     int_enum = EnumIntegerField(IntegerEnum, null=True, default=None, blank=True)
     int_enum_not_editable = EnumIntegerField(IntegerEnum, default=IntegerEnum.A, editable=False)
 
-    zero2 = EnumIntegerField(ZeroEnum, default=ZeroEnum.ZERO)
     labeled_enum = EnumField(LabeledEnum, blank=True, null=True)
-
-    zero3 = EnumIntegerField(ZeroEnum, default=0, blank=True)

--- a/tests/models.py
+++ b/tests/models.py
@@ -25,3 +25,5 @@ class MyModel(models.Model):
 
     zero2 = EnumIntegerField(ZeroEnum, default=ZeroEnum.ZERO)
     labeled_enum = EnumField(LabeledEnum, blank=True, null=True)
+
+    zero3 = EnumIntegerField(ZeroEnum, default=0, blank=True)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,5 +1,3 @@
-import django
-
 SECRET_KEY = 'SEKRIT'
 
 INSTALLED_APPS = (
@@ -19,18 +17,11 @@ DATABASES = {
     },
 }
 
-if django.VERSION[0] < 2:
-    MIDDLEWARE_CLASSES = (
-        'django.contrib.sessions.middleware.SessionMiddleware',
-        'django.contrib.auth.middleware.AuthenticationMiddleware',
-        'django.contrib.messages.middleware.MessageMiddleware',
-    )
-else:
-    MIDDLEWARE = (
-        'django.contrib.sessions.middleware.SessionMiddleware',
-        'django.contrib.auth.middleware.AuthenticationMiddleware',
-        'django.contrib.messages.middleware.MessageMiddleware',
-    )
+MIDDLEWARE = (
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+)
 
 # Speed up tests by using a deliberately weak hasher instead of pbkdf/bcrypt:
 PASSWORD_HASHERS = ['django.contrib.auth.hashers.MD5PasswordHasher']

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -6,4 +6,5 @@ from tests.enums import LabeledEnum
 def test_shortness_check():
     class TestModel(models.Model):
         f = EnumField(LabeledEnum, max_length=3, blank=True, null=True)
+        f2 = EnumField(LabeledEnum, blank=True, null=True)
     assert any([m.id == 'enumfields.max_length_fit' for m in TestModel.check()])

--- a/tests/test_django_admin.py
+++ b/tests/test_django_admin.py
@@ -19,7 +19,7 @@ def test_model_admin_post(admin_client):
         'taste': Taste.UMAMI.value,
         'taste_int': Taste.SWEET.value,
         'random_code': secret_uuid,
-        'zero2': ZeroEnum.ZERO.value,
+        'zero': ZeroEnum.ZERO.value,
     }
     response = admin_client.post(url, follow=True, data=post_data)
     response.render()

--- a/tests/test_django_admin.py
+++ b/tests/test_django_admin.py
@@ -2,17 +2,11 @@ import re
 import uuid
 
 import pytest
+from django.urls import reverse
 from enumfields import EnumIntegerField
 
 from .enums import Color, IntegerEnum, Taste, ZeroEnum
 from .models import MyModel
-
-try:
-    from django.core.urlresolvers import reverse  # Django 1.x
-except ImportError:
-    from django.urls import reverse  # Django 2.x
-
-
 
 
 @pytest.mark.django_db
@@ -33,10 +27,7 @@ def test_model_admin_post(admin_client):
 
     assert b"This field is required" not in text
     assert b"Select a valid choice" not in text
-    try:
-        inst = MyModel.objects.get(random_code=secret_uuid)
-    except DoesNotExist:
-        assert False, "Object wasn't created in the database"
+    inst = MyModel.objects.get(random_code=secret_uuid)
     assert inst.color == Color.RED, "Redness not assured"
     assert inst.taste == Taste.UMAMI, "Umami not there"
     assert inst.taste_int == Taste.SWEET, "Not sweet enough"

--- a/tests/test_django_models.py
+++ b/tests/test_django_models.py
@@ -65,13 +65,14 @@ def test_enum_int_field_validators():
 @pytest.mark.django_db
 def test_zero_enum_loads():
     # Verifies that we can save and load enums with the value of 0 (zero).
-    m = MyModel(zero_field=ZeroEnum.ZERO,
-                color=Color.GREEN)
+    m = MyModel(zero=ZeroEnum.ZERO, color=Color.GREEN)
     m.save()
-    assert m.zero_field == ZeroEnum.ZERO
+    assert m.zero == ZeroEnum.ZERO
+    assert m.zero2 == ZeroEnum.ZERO
 
     m = MyModel.objects.get(id=m.id)
-    assert m.zero_field == ZeroEnum.ZERO
+    assert m.zero == ZeroEnum.ZERO
+    assert m.zero2 == ZeroEnum.ZERO
 
 
 @pytest.mark.django_db

--- a/tests/test_django_models.py
+++ b/tests/test_django_models.py
@@ -24,6 +24,10 @@ def test_field_value():
         MyModel.objects.filter(color='xx')[0]
 
 
+def test_descriptor():
+    assert MyModel.color.field.enum is Color
+
+
 @pytest.mark.django_db
 def test_db_value():
     m = MyModel(color=Color.RED)

--- a/tests/test_django_models.py
+++ b/tests/test_django_models.py
@@ -1,5 +1,3 @@
-from enum import IntEnum
-
 from django.db import connection
 
 import pytest

--- a/tests/test_form_fields.py
+++ b/tests/test_form_fields.py
@@ -1,4 +1,3 @@
-import django
 from django.db.models import BLANK_CHOICE_DASH
 from django.forms.models import model_to_dict, modelform_factory
 
@@ -17,19 +16,13 @@ def get_form(**kwargs):
 @pytest.mark.django_db
 def test_unbound_form_with_instance():
     form = get_form()
-    if django.VERSION >= (1, 11):
-        assert 'value="r" selected' in str(form["color"])
-    else:
-        assert 'value="r" selected="selected"' in str(form["color"])
+    assert 'value="r" selected' in str(form["color"])
 
 
 @pytest.mark.django_db
 def test_bound_form_with_instance():
     form = get_form(data={"color": "g"})
-    if django.VERSION >= (1, 11):
-        assert 'value="g" selected' in str(form["color"])
-    else:
-        assert 'value="g" selected="selected"' in str(form["color"])
+    assert 'value="g" selected' in str(form["color"])
 
 
 def test_choices():

--- a/tests/test_form_fields.py
+++ b/tests/test_form_fields.py
@@ -9,7 +9,7 @@ from .models import MyModel
 
 def get_form(**kwargs):
     instance = MyModel(color=Color.RED)
-    FormClass = modelform_factory(MyModel, fields=("color", "zero2", "int_enum"))
+    FormClass = modelform_factory(MyModel, fields=("color", "zero", "int_enum"))
     return FormClass(instance=instance, **kwargs)
 
 
@@ -33,15 +33,15 @@ def test_bound_form_with_instance_empty():
 
 def test_choices():
     form = get_form()
-    assert form.base_fields["zero2"].choices == [(0, 'Zero'), (1, 'One')]
+    assert form.base_fields["zero"].choices == [(0, 'Zero'), (1, 'One')]
     assert form.base_fields["int_enum"].choices == BLANK_CHOICE_DASH + [(0, 'foo'), (1, 'B')]
 
 
 def test_validation():
-    form = get_form(data={"color": Color.GREEN, "zero2": ZeroEnum.ZERO})
+    form = get_form(data={"color": Color.GREEN, "zero": ZeroEnum.ZERO})
     assert form.is_valid(), form.errors
 
-    instance = MyModel(color=Color.RED, zero2=ZeroEnum.ZERO)
-    data = model_to_dict(instance, fields=("color", "zero2", "int_enum"))
+    instance = MyModel(color=Color.RED, zero=ZeroEnum.ZERO)
+    data = model_to_dict(instance, fields=("color", "zero", "int_enum"))
     form = get_form(data=data)
     assert form.is_valid(), form.errors

--- a/tests/test_form_fields.py
+++ b/tests/test_form_fields.py
@@ -25,6 +25,12 @@ def test_bound_form_with_instance():
     assert 'value="g" selected' in str(form["color"])
 
 
+@pytest.mark.django_db
+def test_bound_form_with_instance_empty():
+    form = get_form(data={"color": None})
+    assert 'value="" selected' in str(form["color"])
+
+
 def test_choices():
     form = get_form()
     assert form.base_fields["zero2"].choices == [(0, 'Zero'), (1, 'One')]

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -48,7 +48,7 @@ def test_serialize(int_names):
 def test_deserialize(lenient_data, lenient_serializer):
     secret_uuid = str(uuid.uuid4())
     data = {
-        'color': Color.BLUE.value,
+        'color': Color.BLUE,
         'taste': Taste.UMAMI.value,
         'int_enum': IntegerEnum.B.value,
         'random_code': secret_uuid,

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,19 +1,13 @@
-import django
 from django.conf import settings
-from django.conf.urls import include, url
+from django.urls import re_path
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 
 admin.autodiscover()
 
-if django.VERSION[0] < 2:
-    urlpatterns = [
-        url(r'^admin/', include(admin.site.urls)),
-    ]
-else:
-    urlpatterns = [
-        url(r'^admin/', admin.site.urls),
-    ]
+urlpatterns = [
+    re_path(r'^admin/', admin.site.urls),
+]
 
 if settings.DEBUG:
     urlpatterns = staticfiles_urlpatterns() + urlpatterns

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,13 @@
 [tox]
 envlist =
-    py{35,36}-django{111}, py{35,36,37}-django{20}, py{36,37}-django{21,22,30}
+    py{36,37}-django{22,30,31}
 
 [testenv]
 setenv = PYTHONPATH = {toxinidir}
 commands = py.test -s tests
 deps =
-    django{111}: djangorestframework<3.7
-    django{20,21,22,30}: djangorestframework>=3.7
+    djangorestframework>=3.7
     pytest-django==3.8.0
-    django111: Django>=1.11,<2
-    django20: Django>=2.0,<2.1
-    django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
+    django31: Django>=3.1,<3.2

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,11 @@ envlist =
 
 [testenv]
 setenv = PYTHONPATH = {toxinidir}
-commands = py.test -s tests
+commands = py.test -s tests --cov=enumfields --cov-report=term-missing
 deps =
     djangorestframework>=3.7
-    pytest-django==3.8.0
+    pytest-django
+    pytest-coverage
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2


### PR DESCRIPTION
- Drop support for EOL Django versions < 2 and add 3.1
- Add `pytest-coverage` in `tox` and bring test coverage to 100%.