### PR TITLE
Use enum value for EnumField choices

### DIFF
--- a/enumfields/fields.py
+++ b/enumfields/fields.py
@@ -39,7 +39,7 @@ class EnumFieldMixin:
 
         if "choices" not in options:
             options["choices"] = [  # choices for the TypedChoiceField
-                (i, getattr(i, 'label', i.name))
+                (i.value, getattr(i, 'label', i.name))
                 for i in self.enum
             ]
 


### PR DESCRIPTION
Use the enum instance value instead of the Enum instance itself when
automatically populating the choices parameter of EnumField. This
better maches Django's Chioices class and the custom Enum class
provided in this library.